### PR TITLE
fix instrumented async local storage

### DIFF
--- a/.changeset/fuzzy-storage-hooks.md
+++ b/.changeset/fuzzy-storage-hooks.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Keep the server middleware's AsyncLocalStorage available when module instrumentation snapshots mutable exports.

--- a/src/compiler/runtime/type.ts
+++ b/src/compiler/runtime/type.ts
@@ -11,6 +11,7 @@ export type Runtime = {
 	urlPatterns: typeof import("./variables.js").urlPatterns;
 	disableAsyncLocalStorage: typeof import("./variables.js").disableAsyncLocalStorage;
 	serverAsyncLocalStorage: typeof import("./variables.js").serverAsyncLocalStorage;
+	getServerAsyncLocalStorage: typeof import("./variables.js").getServerAsyncLocalStorage;
 	experimentalMiddlewareLocaleSplitting: typeof import("./variables.js").experimentalMiddlewareLocaleSplitting;
 	isServer: typeof import("./variables.js").isServer;
 	experimentalStaticLocale: typeof import("./variables.js").experimentalStaticLocale;

--- a/src/compiler/runtime/variables.js
+++ b/src/compiler/runtime/variables.js
@@ -77,6 +77,18 @@ export const urlPatterns = [];
  */
 export let serverAsyncLocalStorage = undefined;
 
+/**
+ * Returns the current server-side async local storage instance.
+ *
+ * Accessing the mutable value through a function keeps it observable when
+ * module interceptors wrap exported bindings and snapshot their initial value.
+ *
+ * @returns {ParaglideAsyncLocalStorage | undefined}
+ */
+export function getServerAsyncLocalStorage() {
+	return serverAsyncLocalStorage;
+}
+
 export const disableAsyncLocalStorage = false;
 
 export const experimentalMiddlewareLocaleSplitting = false;

--- a/src/compiler/server/create-server-file.test.ts
+++ b/src/compiler/server/create-server-file.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, expect, test } from "vitest";
+import { createServerFile } from "./create-server-file.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true }))
+	);
+});
+
+test("uses the initialized AsyncLocalStorage when an import interceptor snapshots the initial export", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "paraglide-server-"));
+	temporaryDirectories.push(directory);
+
+	const serverCode = createServerFile({
+		compiledBundles: [],
+		compilerOptions: {
+			disableAsyncLocalStorage: false,
+			experimentalMiddlewareLocaleSplitting: false,
+		},
+	}).replace('"./runtime.js"', '"./runtime-wrapper.mjs"');
+
+	await writeFile(join(directory, "server.mjs"), serverCode);
+	await writeFile(
+		join(directory, "runtime-real.mjs"),
+		`export let serverAsyncLocalStorage;
+export const disableAsyncLocalStorage = false;
+export function overwriteServerAsyncLocalStorage(value) {
+  serverAsyncLocalStorage = value;
+}
+export function getServerAsyncLocalStorage() {
+  return serverAsyncLocalStorage;
+}
+export const baseLocale = "en";
+export function isExcludedByRouteStrategy() {
+  return true;
+}`
+	);
+	await writeFile(
+		join(directory, "runtime-wrapper.mjs"),
+		`import * as runtime from "./runtime-real.mjs";
+export const serverAsyncLocalStorage = runtime.serverAsyncLocalStorage;
+export const disableAsyncLocalStorage = runtime.disableAsyncLocalStorage;
+export const overwriteServerAsyncLocalStorage = runtime.overwriteServerAsyncLocalStorage;
+export const getServerAsyncLocalStorage = runtime.getServerAsyncLocalStorage;
+export const baseLocale = runtime.baseLocale;
+export const isExcludedByRouteStrategy = runtime.isExcludedByRouteStrategy;`
+	);
+
+	const server = await import(
+		pathToFileURL(join(directory, "server.mjs")).href
+	);
+	const response = await server.paraglideMiddleware(
+		new Request("https://example.com/api/ready"),
+		() => new Response("ready")
+	);
+
+	expect(response.status).toBe(200);
+	expect(await response.text()).toBe("ready");
+});

--- a/src/compiler/server/create-server-file.ts
+++ b/src/compiler/server/create-server-file.ts
@@ -37,16 +37,25 @@ ${injectCode("./middleware.js")}
 	const innerIndent = `${indent}  `;
 	const asyncLocalStorageBlock = args.compilerOptions.disableAsyncLocalStorage
 		? [
-				`${indent}if (!runtime.serverAsyncLocalStorage) {`,
-				`${innerIndent}runtime.overwriteServerAsyncLocalStorage(createMockAsyncLocalStorage());`,
+				`${indent}requestAsyncLocalStorage = runtime.getServerAsyncLocalStorage();`,
+				`${indent}if (!requestAsyncLocalStorage) {`,
+				`${innerIndent}requestAsyncLocalStorage = createMockAsyncLocalStorage();`,
+				`${innerIndent}runtime.overwriteServerAsyncLocalStorage(requestAsyncLocalStorage);`,
 				`${indent}}`,
 			]
 		: [
-				`${indent}if (!runtime.disableAsyncLocalStorage && !runtime.serverAsyncLocalStorage) {`,
+				`${indent}requestAsyncLocalStorage = runtime.getServerAsyncLocalStorage();`,
+				`${indent}if (!runtime.disableAsyncLocalStorage && !requestAsyncLocalStorage) {`,
 				`${innerIndent}const { AsyncLocalStorage } = await import("async_hooks");`,
-				`${innerIndent}runtime.overwriteServerAsyncLocalStorage(new AsyncLocalStorage());`,
-				`${indent}} else if (!runtime.serverAsyncLocalStorage) {`,
-				`${innerIndent}runtime.overwriteServerAsyncLocalStorage(createMockAsyncLocalStorage());`,
+				`${innerIndent}requestAsyncLocalStorage = runtime.getServerAsyncLocalStorage();`,
+				`${innerIndent}if (!requestAsyncLocalStorage) {`,
+				`${innerIndent}  requestAsyncLocalStorage = new AsyncLocalStorage();`,
+				`${innerIndent}  runtime.overwriteServerAsyncLocalStorage(requestAsyncLocalStorage);`,
+				`${innerIndent}}`,
+				`${indent}}`,
+				`${indent}if (!requestAsyncLocalStorage) {`,
+				`${innerIndent}requestAsyncLocalStorage = createMockAsyncLocalStorage();`,
+				`${innerIndent}runtime.overwriteServerAsyncLocalStorage(requestAsyncLocalStorage);`,
 				`${indent}}`,
 			];
 

--- a/src/compiler/server/middleware.js
+++ b/src/compiler/server/middleware.js
@@ -92,6 +92,7 @@ import * as runtime from "./runtime.js";
  * ```
  */
 export async function paraglideMiddleware(request, resolve, options) {
+	let requestAsyncLocalStorage = runtime.serverAsyncLocalStorage;
 	// %async-local-storage
 	const url = resolveMiddlewareUrl(request, options?.effectiveRequestUrl);
 	const origin = url.origin;
@@ -102,7 +103,7 @@ export async function paraglideMiddleware(request, resolve, options) {
 		/** @type {Set<string>} */
 		const messageCalls = new Set();
 		return /** @type {Response} */ (
-			await runtime.serverAsyncLocalStorage?.run(
+			await requestAsyncLocalStorage?.run(
 				{ locale, origin, messageCalls },
 				() => resolve({ locale, request: newRequest })
 			)
@@ -156,7 +157,7 @@ export async function paraglideMiddleware(request, resolve, options) {
 	/** @type {Set<string>} */
 	const messageCalls = new Set();
 
-	const response = await runtime.serverAsyncLocalStorage?.run(
+	const response = await requestAsyncLocalStorage?.run(
 		{ locale, origin, messageCalls },
 		() => resolve({ locale, request: newRequest })
 	);

--- a/src/compiler/server/runtime.d.ts
+++ b/src/compiler/server/runtime.d.ts
@@ -15,6 +15,7 @@ export declare const {
 	cookieName,
 	urlPatterns,
 	serverAsyncLocalStorage,
+	getServerAsyncLocalStorage,
 	experimentalMiddlewareLocaleSplitting,
 	isServer,
 	disableAsyncLocalStorage,


### PR DESCRIPTION
## Summary

- keep the active server `AsyncLocalStorage` observable through ESM instrumentation wrappers
- initialize the request-local reference from a stable runtime getter
- cover import interceptors that snapshot the initially undefined exported binding

## Root cause

`import-in-the-middle/register-hooks.mjs`, as used by SvelteKit server instrumentation, can wrap the generated runtime module and snapshot `serverAsyncLocalStorage` while it is still `undefined`. Paraglide later updates the real mutable export, but the wrapper keeps returning the stale value. The middleware then skips `.run()` and returns `undefined`, causing SvelteKit to fail the request.

## Impact

SvelteKit applications can enable server tracing and instrumentation without Paraglide middleware returning an undefined response.

Fixes #725.

## Validation

- reproduced the original HTTP 500 with `Promatur/paraglide-reproduction`
- verified the same reproduction returns HTTP 200 with this patch and `register-hooks.mjs` enabled
- `pnpm vitest run src/compiler/server/create-server-file.test.ts src/compiler/server/middleware.test.ts src/compiler/runtime/track-message-call.test.ts` (33 passed, 1 skipped)
- `pnpm exec tsc --noEmit`
- `pnpm build`
