### PR TITLE
fix compiler inputs for local declarations

### DIFF
--- a/.changeset/fix-registry-declaration-inputs.md
+++ b/.changeset/fix-registry-declaration-inputs.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Infer message inputs referenced by local formatter declarations so generated registry-based messages receive their inputs at runtime.

--- a/src/compiler/compile-annotation.ts
+++ b/src/compiler/compile-annotation.ts
@@ -1,4 +1,5 @@
 import type {
+	Declaration,
 	FunctionReference,
 	Literal,
 	VariableReference,
@@ -37,7 +38,8 @@ export function registryFunctionNamesForDisplay(): string {
 export function compileAnnotation(
 	str: string,
 	locale: string,
-	annotation?: FunctionReference
+	annotation?: FunctionReference,
+	declarations?: readonly Declaration[]
 ): string {
 	if (!annotation) {
 		return str;
@@ -45,12 +47,13 @@ export function compileAnnotation(
 	if (annotation.name === "relativetime") {
 		validateRelativeTimeOptions(annotation);
 	}
-	return `registry.${annotation.name}("${locale}", ${str}, ${compileOptions(annotation.name, annotation.options)})`;
+	return `registry.${annotation.name}("${locale}", ${str}, ${compileOptions(annotation.name, annotation.options, declarations)})`;
 }
 
 function compileOptions(
 	annotationName: string,
-	options: FunctionReference["options"]
+	options: FunctionReference["options"],
+	declarations?: readonly Declaration[]
 ): string {
 	if (options.length === 0) {
 		return "{}";
@@ -60,7 +63,8 @@ function compileOptions(
 			`${option.name}: ${compileOptionLiteralOrVarRef(
 				annotationName,
 				option.name,
-				option.value
+				option.value,
+				declarations
 			)}`
 	);
 	const code = "{ " + entries.join(", ") + " }";
@@ -97,13 +101,14 @@ const jsNonNegativeIntegerPattern = /^(?:0|[1-9]\d*)$/;
 function compileOptionLiteralOrVarRef(
 	annotationName: string,
 	optionName: string,
-	value: Literal | VariableReference
+	value: Literal | VariableReference,
+	declarations?: readonly Declaration[]
 ): string {
 	if (value.type === "variable-reference") {
 		if (annotationName === "relativetime" && optionName === "unit") {
-			return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.name)})`;
+			return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileVariableAccess(value.name, declarations)})`;
 		}
-		return compileInputAccess(value.name);
+		return compileVariableAccess(value.name, declarations);
 	}
 
 	if (
@@ -111,7 +116,7 @@ function compileOptionLiteralOrVarRef(
 		optionName === "unit" &&
 		isDollarVariableReference(value.value)
 	) {
-		return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.value.slice(1))})`;
+		return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileVariableAccess(value.value.slice(1), declarations)})`;
 	}
 
 	if (shouldEmitNumberLiteral(annotationName, optionName, value.value)) {
@@ -123,6 +128,21 @@ function compileOptionLiteralOrVarRef(
 	}
 
 	return `"${escapeForDoubleQuoteString(value.value)}"`;
+}
+
+function compileVariableAccess(
+	name: string,
+	declarations?: readonly Declaration[]
+): string {
+	if (
+		declarations?.some(
+			(declaration) =>
+				declaration.type === "local-variable" && declaration.name === name
+		)
+	) {
+		return name;
+	}
+	return compileInputAccess(name);
 }
 
 function shouldEmitNumberLiteral(

--- a/src/compiler/compile-bundle.test.ts
+++ b/src/compiler/compile-bundle.test.ts
@@ -65,6 +65,60 @@ test("compiles to jsdoc", async () => {
 	);
 });
 
+test("propagates inferred pattern formatter inputs through the bundle", () => {
+	const mockBundle: BundleNested = {
+		id: "formatted",
+		declarations: [],
+		messages: [
+			{
+				id: "message-id",
+				bundleId: "formatted",
+				locale: "en",
+				selectors: [],
+				variants: [
+					{
+						id: "variant-id",
+						messageId: "message-id",
+						matches: [],
+						pattern: [
+							{
+								type: "expression",
+								arg: { type: "variable-reference", name: "count" },
+								annotation: {
+									type: "function-reference",
+									name: "number",
+									options: [
+										{
+											name: "minimumFractionDigits",
+											value: {
+												type: "variable-reference",
+												name: "digits",
+											},
+										},
+									],
+								},
+							},
+						],
+					},
+				],
+			},
+		],
+	};
+
+	const result = compileBundle({
+		bundle: mockBundle,
+		fallbackMap: { en: "en" },
+		messageReferenceExpression: (locale) => `${locale}_formatted`,
+		settings: { locales: ["en"] } as ProjectSettings,
+	});
+
+	expect(
+		result.bundle.node.declarations?.map((declaration) => declaration.name)
+	).toEqual(["count", "digits"]);
+	expect(result.messages.en?.code).toContain("i?.digits");
+	expect(result.bundle.code).toContain("((inputs, options = {})");
+});
+
 test("uses the base locale as the exhaustive locale branch", () => {
 	const mockBundle: BundleNested = {
 		id: "greeting",

--- a/src/compiler/compile-bundle.ts
+++ b/src/compiler/compile-bundle.ts
@@ -18,6 +18,10 @@ import { toSafeModuleId } from "./safe-module-id.js";
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
 import type { CompilerOptions } from "./compiler-options.js";
 import { perLocaleBuildStaticLocaleExpression } from "./per-locale-build.js";
+import {
+	getEffectiveDeclarations,
+	getInputVariables,
+} from "./input-variables.js";
 
 export type CompiledBundleWithMessages = {
 	/** The compilation result for the bundle index */
@@ -44,10 +48,19 @@ export const compileBundle = (args: {
 	experimentalStaticLocale?: CompilerOptions["experimentalStaticLocale"];
 }): CompiledBundleWithMessages => {
 	const compiledMessages: Record<string, Compiled<Message>> = {};
+	const effectiveBundle = {
+		...args.bundle,
+		declarations: getEffectiveDeclarations(
+			args.bundle.declarations,
+			args.bundle.messages.flatMap((message) =>
+				message.variants.map((variant) => variant.pattern)
+			)
+		),
+	};
 	const safeBundleId = toSafeModuleId(args.bundle.id);
 	const inputTypeAliasName = toBundleInputTypeAliasName(safeBundleId);
-	const matchTypes = collectInputMatchTypes(args.bundle);
-	const hasMarkup = bundleHasMarkup(args.bundle);
+	const matchTypes = collectInputMatchTypes(effectiveBundle);
+	const hasMarkup = bundleHasMarkup(effectiveBundle);
 
 	for (const message of args.bundle.messages) {
 		if (compiledMessages[message.locale]) {
@@ -55,7 +68,7 @@ export const compileBundle = (args: {
 		}
 
 		const compiledMessage = compileMessage(
-			args.bundle.declarations,
+			effectiveBundle.declarations,
 			message,
 			message.variants,
 			matchTypes,
@@ -68,7 +81,7 @@ export const compileBundle = (args: {
 
 	return {
 		bundle: compileBundleFunction({
-			bundle: args.bundle,
+			bundle: effectiveBundle,
 			availableLocales: Object.keys(args.fallbackMap),
 			messageReferenceExpression: args.messageReferenceExpression,
 			settings: args.settings,
@@ -124,9 +137,7 @@ const compileBundleFunction = (args: {
 	 */
 	inputTypeAliasName: string;
 }): Compiled<Bundle> => {
-	const inputs = args.bundle.declarations.filter(
-		(decl) => decl.type === "input-variable"
-	);
+	const inputs = getInputVariables(args.bundle.declarations);
 	const hasInputs = inputs.length > 0;
 	const safeBundleId = toSafeModuleId(args.bundle.id);
 
@@ -450,9 +461,9 @@ function buildMarkupSchemaType(
 ): string {
 	const tagAccumulators = new Map<string, MarkupTagAccumulator>();
 	const inputVariableNames = new Set(
-		bundle.declarations
-			.filter((declaration) => declaration.type === "input-variable")
-			.map((declaration) => declaration.name)
+		getInputVariables(bundle.declarations).map(
+			(declaration) => declaration.name
+		)
 	);
 
 	for (const message of bundle.messages) {
@@ -643,9 +654,7 @@ function renderTypeObjectKey(name: string): string {
 
 function collectInputMatchTypes(bundle: BundleNested): InputMatchTypes {
 	const inputNames = new Set(
-		bundle.declarations
-			?.filter((decl) => decl.type === "input-variable")
-			.map((decl) => decl.name) ?? []
+		getInputVariables(bundle.declarations).map((decl) => decl.name)
 	);
 	const matchTypes: InputMatchTypes = new Map();
 

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -28,6 +28,34 @@ test("compiles a variable reference local variable", () => {
 	expect(code).toEqual("const myVar = i?.name;");
 });
 
+test("compiles a local variable reference as a local access", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declarations: [
+			{
+				type: "local-variable",
+				name: "base",
+				value: { type: "expression", arg: { type: "literal", value: "42" } },
+			},
+		],
+		declaration: {
+			type: "local-variable",
+			name: "formatted",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "base" },
+				annotation: {
+					type: "function-reference",
+					name: "number",
+					options: [],
+				},
+			},
+		},
+	});
+
+	expect(code).toBe('const formatted = registry.number("en", base, {});');
+});
+
 test("compiles a variable reference local variable with a non-identifier name", () => {
 	const code = compileLocalVariable({
 		locale: "en",

--- a/src/compiler/compile-local-variable.ts
+++ b/src/compiler/compile-local-variable.ts
@@ -1,4 +1,9 @@
-import type { Literal, LocalVariable, VariableReference } from "@inlang/sdk";
+import type {
+	Declaration,
+	Literal,
+	LocalVariable,
+	VariableReference,
+} from "@inlang/sdk";
 import { compileInputAccess } from "./variable-access.js";
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
 import { compileAnnotation } from "./compile-annotation.js";
@@ -17,23 +22,97 @@ import { compileAnnotation } from "./compile-annotation.js";
 export function compileLocalVariable(args: {
 	locale: string;
 	declaration: LocalVariable;
+	declarations?: readonly Declaration[];
 }): string {
 	const annotation = args.declaration.value.annotation;
 
 	const value = compileAnnotation(
-		compileLiteralOrVarRef(args.declaration.value.arg),
+		compileLiteralOrVarRef(args.declaration.value.arg, args.declarations),
 		args.locale,
-		annotation
+		annotation,
+		args.declarations
 	);
 
 	return `const ${args.declaration.name} = ${value};`;
 }
 
-function compileLiteralOrVarRef(value: Literal | VariableReference): string {
+/**
+ * Compiles local declarations in dependency order so a local can reference a
+ * declaration that appears later in the source bundle.
+ */
+export function compileLocalVariables(args: {
+	locale: string;
+	declarations: readonly Declaration[];
+}): string[] {
+	const localDeclarations = args.declarations.filter(
+		(declaration): declaration is LocalVariable =>
+			declaration.type === "local-variable"
+	);
+	const localByName = new Map(
+		localDeclarations.map((declaration) => [declaration.name, declaration])
+	);
+	const ordered: LocalVariable[] = [];
+	const visited = new Set<string>();
+	const visiting = new Set<string>();
+
+	const visit = (declaration: LocalVariable): void => {
+		if (visited.has(declaration.name)) return;
+		if (visiting.has(declaration.name)) return;
+
+		visiting.add(declaration.name);
+		const references =
+			declaration.value.arg.type === "variable-reference"
+				? [declaration.value.arg.name]
+				: [];
+		for (const option of declaration.value.annotation?.options ?? []) {
+			if (option.value.type === "variable-reference") {
+				references.push(option.value.name);
+			} else if (
+				declaration.value.annotation?.name === "relativetime" &&
+				option.name === "unit" &&
+				option.value.value.startsWith("$") &&
+				option.value.value.length > 1
+			) {
+				references.push(option.value.value.slice(1));
+			}
+		}
+		for (const reference of references) {
+			const dependency = localByName.get(reference);
+			if (dependency) visit(dependency);
+		}
+		visiting.delete(declaration.name);
+		visited.add(declaration.name);
+		ordered.push(declaration);
+	};
+
+	for (const declaration of localDeclarations) visit(declaration);
+
+	return ordered.map((declaration) =>
+		compileLocalVariable({
+			declaration,
+			locale: args.locale,
+			declarations: args.declarations,
+		})
+	);
+}
+
+function compileLiteralOrVarRef(
+	value: Literal | VariableReference,
+	declarations?: readonly Declaration[]
+): string {
 	switch (value.type) {
 		case "literal":
 			return `"${escapeForDoubleQuoteString(value.value)}"`;
 		case "variable-reference":
+			if (
+				declarations?.some(
+					(declaration) =>
+						declaration.type === "local-variable" &&
+						declaration.name === value.name
+				)
+			) {
+				return value.name;
+			}
 			return compileInputAccess(value.name);
 	}
 }

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -30,11 +30,159 @@ test("compiles a message with a single variant", async () => {
 	expect(some_message()).toBe("Hello");
 });
 
+test("infers inputs referenced by formatter declarations", async () => {
+	const declarations: Declaration[] = [
+		{
+			type: "local-variable",
+			name: "formatted",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "count" },
+				annotation: {
+					type: "function-reference",
+					name: "number",
+					options: [
+						{ name: "style", value: { type: "literal", value: "unit" } },
+						{ name: "unit", value: { type: "literal", value: "minute" } },
+						{
+							name: "unitDisplay",
+							value: { type: "literal", value: "long" },
+						},
+					],
+				},
+			},
+		},
+	];
+	const message: Message = {
+		locale: "en",
+		bundleId: "with_number",
+		id: "message-id",
+		selectors: [],
+	};
+	const variants: Variant[] = [
+		{
+			id: "1",
+			messageId: "message-id",
+			matches: [],
+			pattern: [
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "formatted" },
+				},
+			],
+		},
+	];
+
+	const compiled = compileMessage(declarations, message, variants);
+
+	const { with_number } = await import(
+		"data:text/javascript;base64," +
+			btoa(
+				createRegistry() +
+					"\nexport const with_number = " +
+					compiled.code.replaceAll("registry.", "")
+			)
+	);
+
+	expect(with_number({ count: 120 })).toBe("120 minutes");
+});
+
+test("infers pattern formatter option inputs", () => {
+	const compiled = compileMessage(
+		[],
+		{
+			locale: "en",
+			bundleId: "formatted",
+			id: "message-id",
+			selectors: [],
+		},
+		[
+			{
+				id: "1",
+				messageId: "message-id",
+				matches: [],
+				pattern: [
+					{
+						type: "expression",
+						arg: { type: "variable-reference", name: "count" },
+						annotation: {
+							type: "function-reference",
+							name: "number",
+							options: [
+								{
+									name: "minimumFractionDigits",
+									value: {
+										type: "variable-reference",
+										name: "digits",
+									},
+								},
+							],
+						},
+					},
+				],
+			},
+		]
+	);
+
+	expect(compiled.code).toContain("(i) =>");
+	expect(compiled.code).toContain("i?.digits");
+});
+
+test("emits local declaration dependencies before their consumers", () => {
+	const compiled = compileMessage(
+		[
+			{
+				type: "local-variable",
+				name: "formatted",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "base" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [],
+					},
+				},
+			},
+			{
+				type: "local-variable",
+				name: "base",
+				value: { type: "expression", arg: { type: "literal", value: "42" } },
+			},
+		],
+		{
+			locale: "en",
+			bundleId: "formatted",
+			id: "message-id",
+			selectors: [],
+		},
+		[
+			{
+				id: "1",
+				messageId: "message-id",
+				matches: [],
+				pattern: [
+					{
+						type: "expression",
+						arg: { type: "variable-reference", name: "formatted" },
+					},
+				],
+			},
+		]
+	);
+
+	expect(compiled.code.indexOf("const base")).toBeLessThan(
+		compiled.code.indexOf("const formatted")
+	);
+});
+
 test("compiles pattern-level annotations to registry calls", async () => {
 	// https://github.com/opral/paraglide-js/issues/694
 	// i18next's `{{count, number}}` imports as an expression with a
 	// function-reference annotation directly on the pattern.
-	const declarations: Declaration[] = [{ type: "input-variable", name: "count" }];
+	const declarations: Declaration[] = [
+		{ type: "input-variable", name: "count" },
+	];
 	const message: Message = {
 		locale: "en",
 		bundleId: "views",
@@ -79,7 +227,9 @@ test("compiles pattern-level annotations to registry calls", async () => {
 });
 
 test("compiles pattern-level annotations in multi-variant messages", async () => {
-	const declarations: Declaration[] = [{ type: "input-variable", name: "count" }];
+	const declarations: Declaration[] = [
+		{ type: "input-variable", name: "count" },
+	];
 	const message: Message = {
 		locale: "en",
 		bundleId: "views_multi",
@@ -673,6 +823,7 @@ test("compiles messages that use plural()", async () => {
 	];
 
 	const compiled = compileMessage(declarations, message, variants);
+	expect(compiled.code).toContain("count: NonNullable<unknown>");
 
 	const { plural_test } = await import(
 		"data:text/javascript;base64," +

--- a/src/compiler/compile-message.ts
+++ b/src/compiler/compile-message.ts
@@ -2,9 +2,13 @@ import type { Declaration, Message, Pattern, Variant } from "@inlang/sdk";
 import { compilePattern } from "./compile-pattern.js";
 import type { Compiled } from "./types.js";
 import { inputsType, type InputMatchTypes } from "./jsdoc-types.js";
-import { compileLocalVariable } from "./compile-local-variable.js";
+import { compileLocalVariables } from "./compile-local-variable.js";
 import { renderInputMatchCondition } from "./match-literals.js";
 import { compileInputAccess } from "./variable-access.js";
+import {
+	getEffectiveDeclarations,
+	getInputVariables,
+} from "./input-variables.js";
 
 /**
  * Returns the compiled message as a string
@@ -21,18 +25,22 @@ export const compileMessage = (
 	if (variants.length == 0) {
 		throw new Error("Message must have at least one variant");
 	}
+	const effectiveDeclarations = getEffectiveDeclarations(
+		declarations,
+		variants.map((variant) => variant.pattern)
+	);
 
 	const hasMultipleVariants = variants.length > 1;
 	return hasMultipleVariants
 		? compileMessageWithMultipleVariants(
-				declarations,
+				effectiveDeclarations,
 				message,
 				variants,
 				matchTypes,
 				inputTypeAliasName
 			)
 		: compileMessageWithOneVariant(
-				declarations,
+				effectiveDeclarations,
 				message,
 				variants,
 				matchTypes,
@@ -53,7 +61,7 @@ function compileMessageWithOneVariant(
 	}
 
 	const hasMarkup = patternHasMarkup(variant.pattern);
-	const inputs = declarations.filter((decl) => decl.type === "input-variable");
+	const inputs = getInputVariables(declarations);
 	const hasInputs = inputs.length > 0;
 	const messageInputType = inputTypeAliasName ?? inputsType(inputs, matchTypes);
 	const compiledPattern = compilePattern({
@@ -62,15 +70,10 @@ function compileMessageWithOneVariant(
 		locale: message.locale,
 	});
 
-	const compiledLocalVariables = [];
-
-	for (const declaration of declarations) {
-		if (declaration.type === "local-variable") {
-			compiledLocalVariables.push(
-				compileLocalVariable({ declaration, locale: message.locale })
-			);
-		}
-	}
+	const compiledLocalVariables = compileLocalVariables({
+		declarations,
+		locale: message.locale,
+	});
 
 	if (!hasMarkup) {
 		const code = `/** @type {(inputs: ${messageInputType}) => LocalizedString} */ (${hasInputs ? "i" : ""}) => {
@@ -122,7 +125,7 @@ function compileMessageWithMultipleVariants(
 	const hasMarkup = variants.some((variant) =>
 		patternHasMarkup(variant.pattern)
 	);
-	const inputs = declarations.filter((decl) => decl.type === "input-variable");
+	const inputs = getInputVariables(declarations);
 	const hasInputs = inputs.length > 0;
 	const messageInputType = inputTypeAliasName ?? inputsType(inputs, matchTypes);
 
@@ -193,15 +196,10 @@ function compileMessageWithMultipleVariants(
 		}
 	}
 
-	const compiledLocalVariables = [];
-
-	for (const declaration of declarations) {
-		if (declaration.type === "local-variable") {
-			compiledLocalVariables.push(
-				compileLocalVariable({ declaration, locale: message.locale })
-			);
-		}
-	}
+	const compiledLocalVariables = compileLocalVariables({
+		declarations,
+		locale: message.locale,
+	});
 
 	if (!hasMarkup) {
 		const code = `/** @type {(inputs: ${messageInputType}) => LocalizedString} */ (${hasInputs ? "i" : ""}) => {${compiledLocalVariables.join("\n\t")}

--- a/src/compiler/compile-pattern.ts
+++ b/src/compiler/compile-pattern.ts
@@ -172,7 +172,7 @@ function compileExpression(
 		);
 	}
 
-	return compileAnnotation(value, locale, annotation);
+	return compileAnnotation(value, locale, annotation, declarations);
 }
 
 function compileExpressionValue(
@@ -232,7 +232,9 @@ function compileMarkupAttributes(attributes: Attribute[]): string {
 	return `{ ${attributes
 		.map((attribute) => {
 			const value =
-				attribute.value === true ? "true" : stringLiteral(attribute.value.value);
+				attribute.value === true
+					? "true"
+					: stringLiteral(attribute.value.value);
 			return `${stringLiteral(attribute.name)}: ${value}`;
 		})
 		.join(", ")} }`;

--- a/src/compiler/input-variables.test.ts
+++ b/src/compiler/input-variables.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "vitest";
+import { getInputVariables } from "./input-variables.js";
+
+test("infers inputs from local declaration references and dynamic units", () => {
+	const inputs = getInputVariables([
+		{
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{
+							name: "unit",
+							value: { type: "literal", value: "$unit" },
+						},
+					],
+				},
+			},
+		},
+	]);
+
+	expect(inputs.map((input) => input.name)).toEqual(["duration", "unit"]);
+});
+
+test("infers inputs referenced by pattern formatter options", () => {
+	const inputs = getInputVariables(
+		[],
+		[
+			[
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [
+							{
+								name: "minimumFractionDigits",
+								value: { type: "variable-reference", name: "digits" },
+							},
+						],
+					},
+				},
+			],
+		]
+	);
+
+	expect(inputs.map((input) => input.name)).toEqual(["count", "digits"]);
+});

--- a/src/compiler/input-variables.ts
+++ b/src/compiler/input-variables.ts
@@ -1,0 +1,104 @@
+import type { Declaration, InputVariable, Option, Pattern } from "@inlang/sdk";
+
+/**
+ * Returns the declared input variables plus inputs referenced by local
+ * declarations without a corresponding declaration.
+ *
+ * Message Format permits local declarations such as `local formatted = count:
+ * number` without an explicit `input count` declaration. The generated local
+ * variable still reads `i.count`, so those references must be reflected in the
+ * generated function signature and input type.
+ */
+export function getInputVariables(
+	declarations: readonly Declaration[],
+	patterns: readonly Pattern[] = []
+): InputVariable[] {
+	const declaredNames = new Set(
+		declarations.map((declaration) => declaration.name)
+	);
+	const inputs = declarations.filter(
+		(declaration): declaration is InputVariable =>
+			declaration.type === "input-variable"
+	);
+
+	const references: string[] = [];
+	for (const declaration of declarations) {
+		if (declaration.type !== "local-variable") continue;
+
+		if (declaration.value.arg.type === "variable-reference") {
+			references.push(declaration.value.arg.name);
+		}
+		collectOptionReferences(
+			declaration.value.annotation?.name,
+			declaration.value.annotation?.options ?? [],
+			references
+		);
+	}
+
+	for (const pattern of patterns) {
+		for (const part of pattern) {
+			if (part.type === "expression") {
+				if (part.arg.type === "variable-reference") {
+					references.push(part.arg.name);
+				}
+				collectOptionReferences(
+					part.annotation?.name,
+					part.annotation?.options ?? [],
+					references
+				);
+			} else if (
+				part.type === "markup-start" ||
+				part.type === "markup-end" ||
+				part.type === "markup-standalone"
+			) {
+				collectOptionReferences(undefined, part.options ?? [], references);
+			}
+		}
+	}
+
+	for (const name of references) {
+		if (declaredNames.has(name)) continue;
+
+		inputs.push({ type: "input-variable", name });
+		declaredNames.add(name);
+	}
+
+	return inputs;
+}
+
+/**
+ * Adds inferred input declarations to a bundle without changing the order of
+ * existing declarations.
+ */
+export function getEffectiveDeclarations(
+	declarations: readonly Declaration[],
+	patterns: readonly Pattern[] = []
+): Declaration[] {
+	const declaredNames = new Set(
+		declarations.map((declaration) => declaration.name)
+	);
+	const inferredInputs = getInputVariables(declarations, patterns).filter(
+		(input) => !declaredNames.has(input.name)
+	);
+
+	return [...declarations, ...inferredInputs];
+}
+
+function collectOptionReferences(
+	annotationName: string | undefined,
+	options: readonly Option[],
+	references: string[]
+): void {
+	for (const option of options) {
+		if (option.value.type === "variable-reference") {
+			references.push(option.value.name);
+		} else if (
+			annotationName === "relativetime" &&
+			option.name === "unit" &&
+			option.value.value.startsWith("$") &&
+			option.value.value.length > 1
+		) {
+			references.push(option.value.value.slice(1));
+		}
+	}
+}

--- a/src/compiler/output-structure/locale-modules.ts
+++ b/src/compiler/output-structure/locale-modules.ts
@@ -3,6 +3,7 @@ import type { CompiledBundleWithMessages } from "../compile-bundle.js";
 import { toSafeModuleId } from "../safe-module-id.js";
 import { inputsType } from "../jsdoc-types.js";
 import { toBundleInputTypeAliasName } from "../compile-bundle.js";
+import { getInputVariables } from "../input-variables.js";
 
 const localeImportPrefix = "__";
 
@@ -29,10 +30,9 @@ export function generateOutput(
 			const inputTypeAliasName =
 				compiledBundle.inputTypeAliasName ??
 				toBundleInputTypeAliasName(bundleModuleId);
-			const inputs =
-				compiledBundle.bundle.node.declarations?.filter(
-					(decl) => decl.type === "input-variable"
-				) ?? [];
+			const inputs = getInputVariables(
+				compiledBundle.bundle.node.declarations ?? []
+			);
 			return `/** @typedef {${inputsType(inputs, compiledBundle.matchTypes)}} ${inputTypeAliasName} */`;
 		}),
 		settings.locales
@@ -59,10 +59,9 @@ export function generateOutput(
 			const compiledMessage = compiledBundle.messages[locale];
 			const bundleModuleId = toSafeModuleId(compiledBundle.bundle.node.id);
 			const bundleId = compiledBundle.bundle.node.id;
-			const inputs =
-				compiledBundle.bundle.node.declarations?.filter(
-					(decl) => decl.type === "input-variable"
-				) ?? [];
+			const inputs = getInputVariables(
+				compiledBundle.bundle.node.declarations ?? []
+			);
 			const matchTypes = compiledBundle.matchTypes;
 			const inputTypeAliasName =
 				compiledBundle.inputTypeAliasName ??

--- a/src/compiler/output-structure/message-modules.ts
+++ b/src/compiler/output-structure/message-modules.ts
@@ -4,6 +4,7 @@ import { escapeForSingleQuoteString } from "../../services/codegen/escape.js";
 import { toSafeModuleId } from "../safe-module-id.js";
 import { inputsType } from "../jsdoc-types.js";
 import { toBundleInputTypeAliasName } from "../compile-bundle.js";
+import { getInputVariables } from "../input-variables.js";
 
 export function messageReferenceExpression(locale: string, bundleId: string) {
 	return `${toSafeModuleId(locale)}_${toSafeModuleId(bundleId)}`;
@@ -22,10 +23,9 @@ export function generateOutput(
 	for (const compiledBundle of compiledBundles) {
 		const bundleId = compiledBundle.bundle.node.id;
 		const safeModuleId = toSafeModuleId(compiledBundle.bundle.node.id);
-		const inputs =
-			compiledBundle.bundle.node.declarations?.filter(
-				(decl) => decl.type === "input-variable"
-			) ?? [];
+		const inputs = getInputVariables(
+			compiledBundle.bundle.node.declarations ?? []
+		);
 		const matchTypes = compiledBundle.matchTypes;
 		const inputTypeAliasName =
 			compiledBundle.inputTypeAliasName ??


### PR DESCRIPTION
## Summary

Fixes #731.

Registry-function declarations such as `local formatted = count: number ...` can be emitted without an `input count` declaration by `@inlang/plugin-message-format@4.3.0`. The generated message function still reads `i?.count`, so calls fail with `ReferenceError: i is not defined`.

This change:

- infers effective inputs from local declarations, pattern expressions, formatter options, and dynamic relative-time units
- propagates inferred inputs through bundle dispatch, match/markup typing, and both output structures
- resolves local-to-local declaration references and emits local declarations in dependency order
- adds regression coverage for issue #731 and adjacent formatter/declaration cases

## Validation

- `pnpm test` — 409 passed, 7 skipped
- `pnpm exec tsc --noEmit`
- Prettier and Oxlint checks passed