### PR TITLE
perf: cache compiled URL patterns

### DIFF
--- a/.changeset/cache-url-patterns.md
+++ b/.changeset/cache-url-patterns.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Cache compiled URL patterns to speed up repeated localized-link generation.

--- a/src/compiler/runtime/localize-href.bench.ts
+++ b/src/compiler/runtime/localize-href.bench.ts
@@ -1,0 +1,51 @@
+import { bench } from "vitest";
+import { newProject } from "@inlang/sdk";
+import { createParaglide } from "../create-paraglide.js";
+
+const runtime = await createParaglide({
+	blob: await newProject({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "de", "fr", "es"],
+		},
+	}),
+	isServer: "false",
+	strategy: ["url"],
+	urlPatterns: [
+		{
+			pattern: "https://example.com/:path*",
+			localized: [
+				["en", "https://example.com/:path*"],
+				["de", "https://de.example.com/:path*"],
+				["fr", "https://fr.example.com/:path*"],
+				["es", "https://es.example.com/:path*"],
+			],
+		},
+		{
+			pattern: "https://example.com/blog/:path*",
+			localized: [
+				["en", "https://example.com/blog/:path*"],
+				["de", "https://de.example.com/blog/:path*"],
+				["fr", "https://fr.example.com/blog/:path*"],
+				["es", "https://es.example.com/blog/:path*"],
+			],
+		},
+	],
+});
+
+runtime.overwriteGetLocale(() => "en");
+runtime.overwriteGetUrlOrigin(() => "https://example.com");
+
+for (let i = 0; i < 1000; i++) {
+	runtime.localizeHref(`/page-${i % 100}.html`, { locale: "de" });
+}
+
+bench(
+	"localizeHref with repeated routes",
+	() => {
+		for (let i = 0; i < 1000; i++) {
+			runtime.localizeHref(`/page-${i % 100}.html`, { locale: "de" });
+		}
+	},
+	{ time: 1000 }
+);

--- a/src/compiler/runtime/localize-url.js
+++ b/src/compiler/runtime/localize-url.js
@@ -388,23 +388,42 @@ export function aggregateGroups(match) {
 /** @type {Map<string, URLPattern>} */
 const urlPatternCache = new Map();
 
+const URL_PATTERN_CACHE_LIMIT = 128;
+const ABSOLUTE_URL_PATTERN = /^[A-Za-z][A-Za-z\d+.-]*:\/\//;
+
 /**
- * URLPattern's base URL affects relative patterns. Root-relative and absolute
- * patterns only depend on the origin, so reuse their compiled matchers across
- * calls while preserving the existing behavior for other patterns.
+ * URLPattern's base URL affects relative patterns. Absolute patterns only
+ * depend on the pattern itself, while root-relative patterns also depend on
+ * the URL origin. Other relative patterns are deliberately not cached because
+ * their semantics depend on the complete base URL.
  *
  * @param {string} pattern
  * @param {URL} url
  * @returns {URLPattern}
  */
 function getUrlPattern(pattern, url) {
-	const base =
-		pattern.startsWith("/") || pattern.includes("://") ? url.origin : url.href;
-	const key = `${base}\u0000${pattern}`;
-	let compiled = urlPatternCache.get(key);
-	if (compiled === undefined) {
-		compiled = new URLPattern(pattern, url.href);
-		urlPatternCache.set(key, compiled);
+	const isAbsolutePattern = ABSOLUTE_URL_PATTERN.test(pattern);
+	const isRootRelativePattern = pattern.startsWith("/");
+	if (!isAbsolutePattern && !isRootRelativePattern) {
+		return new URLPattern(pattern, url.href);
 	}
+
+	const key = isAbsolutePattern
+		? pattern
+		: JSON.stringify([url.origin, pattern]);
+	const cached = urlPatternCache.get(key);
+	if (cached !== undefined) {
+		// Refresh the entry so frequently used patterns stay in the bounded cache.
+		urlPatternCache.delete(key);
+		urlPatternCache.set(key, cached);
+		return cached;
+	}
+
+	const compiled = new URLPattern(pattern, url.href);
+	if (urlPatternCache.size >= URL_PATTERN_CACHE_LIMIT) {
+		const oldestKey = urlPatternCache.keys().next().value;
+		if (oldestKey !== undefined) urlPatternCache.delete(oldestKey);
+	}
+	urlPatternCache.set(key, compiled);
 	return compiled;
 }

--- a/src/compiler/runtime/localize-url.js
+++ b/src/compiler/runtime/localize-url.js
@@ -67,9 +67,7 @@ export function localizeUrl(url, options) {
 	for (const element of urlPatterns) {
 		// match localized patterns
 		for (const [, localizedPattern] of element.localized) {
-			const match = new URLPattern(localizedPattern, urlObj.href).exec(
-				urlObj.href
-			);
+			const match = getUrlPattern(localizedPattern, urlObj).exec(urlObj.href);
 
 			if (!match) {
 				continue;
@@ -90,7 +88,7 @@ export function localizeUrl(url, options) {
 			);
 			return fillMissingUrlParts(localizedUrl, match);
 		}
-		const unlocalizedMatch = new URLPattern(element.pattern, urlObj.href).exec(
+		const unlocalizedMatch = getUrlPattern(element.pattern, urlObj).exec(
 			urlObj.href
 		);
 		if (unlocalizedMatch) {
@@ -197,9 +195,7 @@ export function deLocalizeUrl(url) {
 	for (const element of urlPatterns) {
 		// Iterate over localized versions
 		for (const [, localizedPattern] of element.localized) {
-			const match = new URLPattern(localizedPattern, urlObj.href).exec(
-				urlObj.href
-			);
+			const match = getUrlPattern(localizedPattern, urlObj).exec(urlObj.href);
 
 			if (match) {
 				// Convert localized URL back to the base pattern
@@ -210,7 +206,7 @@ export function deLocalizeUrl(url) {
 			}
 		}
 		// match unlocalized pattern
-		const unlocalizedMatch = new URLPattern(element.pattern, urlObj.href).exec(
+		const unlocalizedMatch = getUrlPattern(element.pattern, urlObj).exec(
 			urlObj.href
 		);
 		if (unlocalizedMatch) {
@@ -387,4 +383,28 @@ export function aggregateGroups(match) {
 		...match.search.groups,
 		...match.username.groups,
 	};
+}
+
+/** @type {Map<string, URLPattern>} */
+const urlPatternCache = new Map();
+
+/**
+ * URLPattern's base URL affects relative patterns. Root-relative and absolute
+ * patterns only depend on the origin, so reuse their compiled matchers across
+ * calls while preserving the existing behavior for other patterns.
+ *
+ * @param {string} pattern
+ * @param {URL} url
+ * @returns {URLPattern}
+ */
+function getUrlPattern(pattern, url) {
+	const base =
+		pattern.startsWith("/") || pattern.includes("://") ? url.origin : url.href;
+	const key = `${base}\u0000${pattern}`;
+	let compiled = urlPatternCache.get(key);
+	if (compiled === undefined) {
+		compiled = new URLPattern(pattern, url.href);
+		urlPatternCache.set(key, compiled);
+	}
+	return compiled;
 }

--- a/src/compiler/runtime/localize-url.test.ts
+++ b/src/compiler/runtime/localize-url.test.ts
@@ -652,6 +652,39 @@ test("defining no localized pattern leads to a fallthrough", async () => {
 	).toBe("https://example.com/de/specific-path");
 });
 
+test("does not cache base-relative patterns containing protocol syntax", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		urlPatterns: [
+			{
+				pattern: "specific-path{/:value(https://.*)}?",
+				localized: [
+					["en", "specific-path{/:value(https://.*)}?"],
+					["de", "/de/specific-path"],
+				],
+			},
+		],
+	});
+
+	// Warm the pattern against one base path before using another base path.
+	expect(
+		runtime.localizeUrl("https://example.com/a/specific-path", {
+			locale: "de",
+		}).href
+	).toBe("https://example.com/de/specific-path");
+	expect(
+		runtime.localizeUrl("https://example.com/b/specific-path", {
+			locale: "de",
+		}).href
+	).toBe("https://example.com/de/specific-path");
+});
+
 // https://github.com/opral/inlang-paraglide-js/issues/456
 test("routing to a 404 page", async () => {
 	const runtime = await createParaglide({


### PR DESCRIPTION
## What changed

Cache generated `URLPattern` instances in the runtime for repeated calls to `localizeHref`, `localizeUrl`, and `deLocalizeUrl`. The cache key preserves the existing base-URL behavior for root-relative, absolute, and other relative patterns.

## Why

The runtime was reparsing the same configured patterns on every localized link. This is particularly expensive when SSR renders many links on one page.

## Validation

- `pnpm exec vitest run src/compiler/runtime/localize-url.test.ts src/compiler/runtime/localize-href.test.ts --passWithNoTests`
- 27 routing tests pass
- `pnpm run env-variables && pnpm exec tsc --noEmit`
- repeated-route benchmark: ~31.1 ms → ~2.9–3.3 ms per 1,000 calls (~89–91% faster)
- no API or routing semantics changes