### PR TITLE
fix: preserve original request in TanStack Start example

### DIFF
--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -79,9 +79,8 @@ const fetch = createStartHandler({ handler: defaultStreamHandler });
 
 export default {
   fetch(request: Request) {
-    return paraglideMiddleware(request, ({ request: localizedRequest }) =>
-      fetch(localizedRequest),
-    );
+    // TanStack Router owns URL rewriting, so keep the original request URL.
+    return paraglideMiddleware(request, () => fetch(request));
   },
 };
 ```

--- a/examples/tanstack-start/src/server.ts
+++ b/examples/tanstack-start/src/server.ts
@@ -10,8 +10,7 @@ const fetch = createStartHandler({
 
 export default {
   fetch(request: Request) {
-    return paraglideMiddleware(request, ({ request: localizedRequest }) =>
-      fetch(localizedRequest),
-    )
+    // TanStack Router owns URL rewriting, so keep the original request URL.
+    return paraglideMiddleware(request, () => fetch(request))
   },
 }


### PR DESCRIPTION
## Summary

- preserve the original request when wrapping the TanStack Start handler with Paraglide middleware
- document why the original URL must be passed through when TanStack Router owns URL rewriting

## Root cause

The example passed Paraglide's de-localized request into TanStack Router while also configuring Router URL rewrites. The two layers then disagreed about the request URL, causing localized navigation to redirect or resolve incorrectly.

## Validation

- `pnpm --filter @inlang/paraglide-js-example-tanstack-start build`
- `git diff --check`