### PR TITLE
perf: speed up incremental generated output writes

### DIFF
--- a/.changeset/fast-output-hashes.md
+++ b/.changeset/fast-output-hashes.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Improve compiler output writes by using Node's synchronous SHA-256 implementation and only creating directories for generated files that changed.

--- a/src/services/file-handling/write-output.bench.ts
+++ b/src/services/file-handling/write-output.bench.ts
@@ -1,0 +1,29 @@
+import { bench } from "vitest";
+import memfs from "memfs";
+import { writeOutput } from "./write-output.js";
+type NodeFs = typeof import("node:fs/promises");
+
+const output = Object.fromEntries(
+	Array.from({ length: 2_000 }, (_, index) => [
+		`messages/bundle-${index}.js`,
+		`export const m${index} = ${JSON.stringify("Hello world")}`,
+	])
+);
+
+bench("write 2,000 generated message modules", async () => {
+	const volume = memfs.Volume.fromJSON({});
+	const fsp = memfs.createFsFromVolume(volume).promises as unknown as NodeFs;
+	await writeOutput({ directory: "/output", output, fs: fsp });
+});
+
+bench("rewrite one of 2,000 generated message modules", async () => {
+	const volume = memfs.Volume.fromJSON({});
+	const fsp = memfs.createFsFromVolume(volume).promises as unknown as NodeFs;
+	const hashes = await writeOutput({ directory: "/output", output, fs: fsp });
+	await writeOutput({
+		directory: "/output",
+		output: { ...output, "messages/bundle-0.js": "changed" },
+		fs: fsp,
+		previousOutputHashes: hashes,
+	});
+});

--- a/src/services/file-handling/write-output.test.ts
+++ b/src/services/file-handling/write-output.test.ts
@@ -109,6 +109,37 @@ test("should write again if the output has changed", async () => {
 	expect(writeFileSpy).toHaveBeenCalledTimes(2);
 });
 
+test("should only create directories for files that changed", async () => {
+	const { writeOutput } = await import("./write-output.js");
+	const fs = mockFs({});
+	const mkdirSpy = vi.spyOn(fs, "mkdir");
+
+	const hashes = await writeOutput({
+		directory: "/output",
+		output: {
+			"messages/first.js": "first",
+			"messages/second.js": "second",
+		},
+		fs,
+	});
+	mkdirSpy.mockClear();
+
+	await writeOutput({
+		directory: "/output",
+		output: {
+			"messages/first.js": "changed",
+			"messages/second.js": "second",
+		},
+		fs,
+		previousOutputHashes: hashes,
+	});
+
+	expect(mkdirSpy).toHaveBeenCalledTimes(1);
+	expect(mkdirSpy).toHaveBeenCalledWith("/output/messages", {
+		recursive: true,
+	});
+});
+
 test("should write files if output has partially changed", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({});

--- a/src/services/file-handling/write-output.ts
+++ b/src/services/file-handling/write-output.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { createHash } from "node:crypto";
 import type nodeFs from "node:fs/promises";
 
 export async function writeOutput(args: {
@@ -11,7 +12,7 @@ export async function writeOutput(args: {
 	const currentOutputHashes = await hashOutput(args.output, args.directory);
 
 	// if the output hasn't changed, don't write it
-	const changedFiles = new Set();
+	const changedFiles = new Set<string>();
 
 	for (const [filePath, hash] of Object.entries(currentOutputHashes)) {
 		if (args.previousOutputHashes?.[filePath] !== hash) {
@@ -39,8 +40,6 @@ export async function writeOutput(args: {
 	// and re-enabled because of https://github.com/opral/inlang-paraglide-js/issues/420
 	if (args.cleanDirectory) {
 		await args.fs.rm(args.directory, { recursive: true, force: true });
-	} else {
-		await args.fs.mkdir(args.directory, { recursive: true });
 	}
 	// Delete files that have been removed
 	// ignore if cleanDirectory is true because the directory will be cleaned anyway
@@ -48,13 +47,20 @@ export async function writeOutput(args: {
 		await deleteRemovedFiles(args.fs, args.directory, filesToDelete);
 	}
 
-	//Create missing directories inside the output directory
+	// Create only the directories needed by files that are about to be written.
+	// On incremental compiles, `output` can contain thousands of unchanged
+	// message modules; creating every parent directory again adds avoidable
+	// filesystem work even though only a handful of files changed.
+	const directoriesToCreate = new Set<string>();
+	for (const filePath of changedFiles) {
+		directoriesToCreate.add(
+			path.dirname(path.resolve(args.directory, filePath))
+		);
+	}
 	await Promise.allSettled(
-		Object.keys(args.output).map(async (filePath) => {
-			const fullPath = path.resolve(args.directory, filePath);
-			const directory = path.dirname(fullPath);
-			await args.fs.mkdir(directory, { recursive: true });
-		})
+		Array.from(directoriesToCreate, (directory) =>
+			args.fs.mkdir(directory, { recursive: true })
+		)
 	);
 
 	//Write files
@@ -129,25 +135,20 @@ async function deleteRemovedFiles(
 	}
 }
 
-async function hashString(input: string): Promise<string> {
-	const encoder = new TextEncoder();
-	const data = encoder.encode(input);
-	const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-	const hashArray = Array.from(new Uint8Array(hashBuffer));
-	return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+function hashString(input: string): string {
+	return createHash("sha256").update(input).digest("hex");
 }
 
 async function hashOutput(
 	output: Record<string, string>,
 	outputDirectory: string
 ): Promise<Record<string, string>> {
-	const hashes: Record<string, string> = {};
-	for (const [filePath, fileContent] of Object.entries(output)) {
+	const entries = Object.entries(output).map(([filePath, fileContent]) => {
 		const combinedContent =
 			fileContent + path.resolve(outputDirectory, filePath);
-		hashes[filePath] = await hashString(combinedContent);
-	}
-	return hashes;
+		return [filePath, hashString(combinedContent)] as const;
+	});
+	return Object.fromEntries(entries);
 }
 
 /**


### PR DESCRIPTION
## What changed

- Replace per-file async WebCrypto hashing with Node's synchronous `createHash` in the Node compiler.
- Only create parent directories for files that changed; avoid recreating every generated directory on incremental builds.
- Add a regression test and a focused 2,000-module benchmark.

## Why

The generated output writer was doing asynchronous SHA-256 work and redundant directory creation for every compile. This is especially visible on incremental dev-server rebuilds with message-modules.

## Measurements

On a 2,000-module fixture, the isolated write path improved from approximately 80.6 ms to 65.6 ms for the first write and from 33.6 ms to 6.4 ms when rewriting one module.

## Validation

- `pnpm exec vitest run src/services/file-handling/write-output.test.ts` — 12/12 passed
- `pnpm exec tsc --noEmit` — passed
- Oxlint on changed files — passed

This is the first layer of a performance stack; the routing fast path is intended to build on this branch.