### PR TITLE
perf: fast path for common locale URL routes

### DIFF
--- a/.changeset/fast-locale-routing.md
+++ b/.changeset/fast-locale-routing.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Add a fast path for common locale-prefix and static-domain URL patterns while preserving the generic URLPattern fallback.

--- a/.changeset/fast-output-hashes.md
+++ b/.changeset/fast-output-hashes.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Improve compiler output writes by using Node's synchronous SHA-256 implementation and only creating directories for generated files that changed.

--- a/src/compiler/runtime/localize-href.bench.ts
+++ b/src/compiler/runtime/localize-href.bench.ts
@@ -33,8 +33,34 @@ const runtime = await createParaglide({
 	],
 });
 
+const genericRuntime = await createParaglide({
+	blob: await newProject({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "de", "fr", "es"],
+		},
+	}),
+	isServer: "false",
+	strategy: ["url"],
+	urlPatterns: [
+		{
+			// A custom group name intentionally keeps this route on the generic
+			// URLPattern fallback while matching the same URLs.
+			pattern: "/:slug(.*)?",
+			localized: [
+				["en", "/:slug(.*)?"],
+				["de", "/de/:slug(.*)?"],
+				["fr", "/fr/:slug(.*)?"],
+				["es", "/es/:slug(.*)?"],
+			],
+		},
+	],
+});
+
 runtime.overwriteGetLocale(() => "en");
 runtime.overwriteGetUrlOrigin(() => "https://example.com");
+genericRuntime.overwriteGetLocale(() => "en");
+genericRuntime.overwriteGetUrlOrigin(() => "https://example.com");
 
 for (let i = 0; i < 1000; i++) {
 	runtime.localizeHref(`/page-${i % 100}.html`, { locale: "de" });
@@ -45,6 +71,20 @@ bench(
 	() => {
 		for (let i = 0; i < 1000; i++) {
 			runtime.localizeHref(`/page-${i % 100}.html`, { locale: "de" });
+		}
+	},
+	{ time: 1000 }
+);
+
+for (let i = 0; i < 1000; i++) {
+	genericRuntime.localizeHref(`/page-${i % 100}.html`, { locale: "de" });
+}
+
+bench(
+	"localizeHref with generic URLPattern fallback",
+	() => {
+		for (let i = 0; i < 1000; i++) {
+			genericRuntime.localizeHref(`/page-${i % 100}.html`, { locale: "de" });
 		}
 	},
 	{ time: 1000 }

--- a/src/compiler/runtime/localize-href.test.ts
+++ b/src/compiler/runtime/localize-href.test.ts
@@ -229,6 +229,8 @@ test("keeps custom URLPattern path expressions on the generic fallback", async (
 			},
 		],
 	});
+	runtime.overwriteGetLocale(() => "en");
+	runtime.overwriteGetUrlOrigin(() => "https://example.com");
 
 	// `(.)` matches exactly one character in URLPattern. A prefix-only
 	// implementation must not broaden this route into a catch-all.

--- a/src/compiler/runtime/localize-href.test.ts
+++ b/src/compiler/runtime/localize-href.test.ts
@@ -209,3 +209,29 @@ test("normalizes mixed-case explicit locales in localizeHref", async () => {
 
 	expect(runtime.localizeHref("/de/about", { locale: "EN" })).toBe("/about");
 });
+
+test("keeps custom URLPattern path expressions on the generic fallback", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		urlPatterns: [
+			{
+				pattern: "/:slug(.)?",
+				localized: [
+					["en", "/:slug(.)?"],
+					["de", "/de/:slug(.)?"],
+				],
+			},
+		],
+	});
+
+	// `(.)` matches exactly one character in URLPattern. A prefix-only
+	// implementation must not broaden this route into a catch-all.
+	expect(runtime.localizeHref("/a", { locale: "de" })).toBe("/de/a");
+	expect(runtime.localizeHref("/about", { locale: "de" })).toBe("/about");
+});

--- a/src/compiler/runtime/localize-url.js
+++ b/src/compiler/runtime/localize-url.js
@@ -408,7 +408,7 @@ export function aggregateGroups(match) {
 const urlPatternCache = new Map();
 
 const URL_PATTERN_CACHE_LIMIT = 128;
-const ABSOLUTE_URL_PATTERN = /^[A-Za-z][A-Za-z\d+.-]*:\/\//;
+const ABSOLUTE_URL_PATTERN = /^(?:[A-Za-z][A-Za-z\d+.-]*|:[A-Za-z][A-Za-z\d_-]*):\/\//;
 
 /**
  * URLPattern's base URL affects relative patterns. Absolute patterns only

--- a/src/compiler/runtime/localize-url.js
+++ b/src/compiler/runtime/localize-url.js
@@ -65,6 +65,20 @@ export function localizeUrl(url, options) {
 
 	// Iterate over URL patterns
 	for (const element of urlPatterns) {
+		// Most applications use a locale prefix (and sometimes a fixed domain)
+		// with a trailing catch-all path. Those routes do not need URLPattern's
+		// parser or matcher on every call. Keep the generic matcher below as the
+		// fallback for every other URLPattern shape. This stays inside the outer
+		// loop so specific patterns retain precedence over a later catch-all.
+		const fastPathLocalized = localizeUrlFastPath(
+			urlObj,
+			targetLocale,
+			element
+		);
+		if (fastPathLocalized !== undefined) {
+			return fastPathLocalized;
+		}
+
 		// match localized patterns
 		for (const [, localizedPattern] of element.localized) {
 			const match = getUrlPattern(localizedPattern, urlObj).exec(urlObj.href);
@@ -193,6 +207,11 @@ export function deLocalizeUrl(url) {
 
 	// Iterate over URL patterns
 	for (const element of urlPatterns) {
+		const fastPathDeLocalized = deLocalizeUrlFastPath(urlObj, element);
+		if (fastPathDeLocalized !== undefined) {
+			return fastPathDeLocalized;
+		}
+
 		// Iterate over localized versions
 		for (const [, localizedPattern] of element.localized) {
 			const match = getUrlPattern(localizedPattern, urlObj).exec(urlObj.href);
@@ -426,4 +445,330 @@ function getUrlPattern(pattern, url) {
 	}
 	urlPatternCache.set(key, compiled);
 	return compiled;
+}
+
+/**
+ * A small, deliberately conservative subset of URLPattern routing.
+ *
+ * The compiler emits routes such as `/:path(.*)?`, `/de/:path*`, or
+ * `https://example.com/:path*`. For those routes matching is equivalent to a
+ * pathname prefix check and (optionally) an origin check. Everything that has
+ * a dynamic host, a custom path regexp, or another URLPattern modifier keeps
+ * using the generic implementation above.
+ *
+ * @typedef {{
+ *   protocol: string | undefined;
+ *   hostname: string | undefined;
+ *   port: string | undefined;
+ *   pathnamePrefix: string;
+ *   pathMode: "segments" | "catch-all-optional" | "catch-all-required";
+ * }} FastPathPattern
+ * @typedef {{
+ *   base: FastPathPattern;
+ *   localized: Array<{ locale: string; pattern: FastPathPattern }>;
+ * }} FastPathRoute
+ */
+
+/** @type {WeakMap<object, FastPathRoute | null>} */
+const fastPathRouteCache = new WeakMap();
+
+/**
+ * @param {URL} urlObj
+ * @param {string} targetLocale
+ * @param {{ pattern: string; localized: Array<[string, string]> }} element
+ * @returns {URL | undefined}
+ */
+function localizeUrlFastPath(urlObj, targetLocale, element) {
+	const route = getFastPathRoute(element);
+	if (route === null) return undefined;
+
+	// Preserve URLPattern's ordering: localized patterns are checked before
+	// the unlocalized pattern, and the first matching pattern wins.
+	for (const localized of route.localized) {
+		const suffix = matchFastPathPattern(localized.pattern, urlObj);
+		if (suffix === undefined) continue;
+
+		const target = route.localized.find(
+			(candidate) => candidate.locale === targetLocale
+		)?.pattern;
+		if (target === undefined) continue;
+
+		return applyFastPathPattern(target, suffix, urlObj);
+	}
+
+	const suffix = matchFastPathPattern(route.base, urlObj);
+	if (suffix !== undefined) {
+		const target = route.localized.find(
+			(candidate) => candidate.locale === targetLocale
+		)?.pattern;
+		if (target !== undefined) {
+			return applyFastPathPattern(target, suffix, urlObj);
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * @param {URL} urlObj
+ * @param {{ pattern: string; localized: Array<[string, string]> }} element
+ * @returns {URL | undefined}
+ */
+function deLocalizeUrlFastPath(urlObj, element) {
+	const route = getFastPathRoute(element);
+	if (route === null) return undefined;
+
+	for (const localized of route.localized) {
+		const suffix = matchFastPathPattern(localized.pattern, urlObj);
+		if (suffix !== undefined) {
+			return applyFastPathPattern(route.base, suffix, urlObj);
+		}
+	}
+
+	const suffix = matchFastPathPattern(route.base, urlObj);
+	if (suffix !== undefined) {
+		return applyFastPathPattern(route.base, suffix, urlObj);
+	}
+
+	return undefined;
+}
+
+/**
+ * @param {{ pattern: string; localized: Array<[string, string]> }} element
+ * @returns {FastPathRoute | null}
+ */
+function getFastPathRoute(element) {
+	const cached = fastPathRouteCache.get(element);
+	if (cached !== undefined) return cached;
+
+	const base = parseFastPathPattern(element.pattern);
+	if (base === undefined) {
+		fastPathRouteCache.set(element, null);
+		return null;
+	}
+
+	const localized = [];
+	for (const [locale, pattern] of element.localized) {
+		const parsed = parseFastPathPattern(pattern);
+		if (parsed === undefined || parsed.pathMode !== base.pathMode) {
+			fastPathRouteCache.set(element, null);
+			return null;
+		}
+		localized.push({ locale, pattern: parsed });
+	}
+
+	const route = { base, localized };
+	fastPathRouteCache.set(element, route);
+	return route;
+}
+
+/**
+ * Parse only catch-all path patterns. In particular, do not treat `:path(.)?`
+ * as a catch-all: URLPattern's `(.)` means exactly one character and cannot be
+ * represented by this prefix matcher without changing routing semantics.
+ *
+ * @param {string} pattern
+ * @returns {FastPathPattern | undefined}
+ */
+function parseFastPathPattern(pattern) {
+	const wildcard = pattern.match(/\/:path(?:\(\.\*\)(?:\?)?|\*)$/);
+	if (wildcard === null || wildcard.index === undefined) return undefined;
+
+	const prefix = pattern.slice(0, wildcard.index);
+	const originAndPath = parseFastPathOriginAndPath(prefix);
+	if (originAndPath === undefined) return undefined;
+	const pathMode = wildcard[0].endsWith("*")
+		? "segments"
+		: wildcard[0].endsWith("?")
+			? "catch-all-optional"
+			: "catch-all-required";
+
+	return { ...originAndPath, pathMode };
+}
+
+/**
+ * @param {string} prefix
+ * @returns {FastPathPattern | undefined}
+ */
+function parseFastPathOriginAndPath(prefix) {
+	if (prefix === "" || prefix.startsWith("/")) {
+		if (hasUrlPatternSyntax(prefix)) return undefined;
+		return {
+			protocol: undefined,
+			hostname: undefined,
+			port: undefined,
+			pathnamePrefix: normalizePathPrefix(prefix),
+			pathMode: "catch-all-optional",
+		};
+	}
+
+	// A `:protocol://host` pattern is common in generated configurations. The
+	// protocol is intentionally left unconstrained, just like URLPattern.
+	const dynamicProtocol = prefix.match(/^:protocol:\/\/([^/]+)(\/.*)?$/);
+	const staticOrigin = prefix.match(
+		/^([A-Za-z][A-Za-z\d+.-]*):\/\/([^/]+)(\/.*)?$/
+	);
+	if (dynamicProtocol !== null) {
+		const dynamicHost = dynamicProtocol[1] ?? "";
+		const hostMatch = dynamicHost.match(/^([^:(){}?*+]+)(?::(\d+))?$/);
+		if (
+			hostMatch === null ||
+			(dynamicProtocol[2] !== undefined &&
+				hasUrlPatternSyntax(dynamicProtocol[2]))
+		) {
+			return undefined;
+		}
+		return {
+			protocol: undefined,
+			hostname: (hostMatch[1] ?? "").toLowerCase(),
+			port: hostMatch[2],
+			pathnamePrefix: normalizePathPrefix(dynamicProtocol[2] ?? ""),
+			pathMode: "catch-all-optional",
+		};
+	}
+
+	if (staticOrigin === null) return undefined;
+
+	const host = staticOrigin[2] ?? "";
+	const pathname = staticOrigin[3];
+	const hostMatch = host.match(/^([^:(){}?*+]+)(?::(\d+))?$/);
+	if (
+		hostMatch === null ||
+		(pathname !== undefined && hasUrlPatternSyntax(pathname))
+	) {
+		return undefined;
+	}
+
+	return {
+		protocol: `${staticOrigin[1]}:`,
+		hostname: (hostMatch[1] ?? "").toLowerCase(),
+		port: normalizePatternPort(hostMatch[2], `${staticOrigin[1]}:`),
+		pathnamePrefix: normalizePathPrefix(pathname ?? ""),
+		pathMode: "catch-all-optional",
+	};
+}
+
+/**
+ * @param {string | undefined} port
+ * @param {string} protocol
+ * @returns {string | undefined}
+ */
+function normalizePatternPort(port, protocol) {
+	if (port === "80" && protocol === "http:") return "";
+	if (port === "443" && protocol === "https:") return "";
+	return port;
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function hasUrlPatternSyntax(value) {
+	return /[:(){}?*+]/.test(value);
+}
+
+/**
+ * @param {string} pathname
+ * @returns {string}
+ */
+function normalizePathPrefix(pathname) {
+	if (pathname === "" || pathname === "/") return "/";
+	return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+/**
+ * @param {FastPathPattern} pattern
+ * @param {URL} urlObj
+ * @returns {string | undefined}
+ */
+function matchFastPathPattern(pattern, urlObj) {
+	if (pattern.protocol !== undefined && pattern.protocol !== urlObj.protocol) {
+		return undefined;
+	}
+	if (
+		pattern.hostname !== undefined &&
+		pattern.hostname !== urlObj.hostname.toLowerCase()
+	) {
+		return undefined;
+	}
+	if (pattern.hostname !== undefined) {
+		const expectedPort =
+			pattern.port ?? defaultPortForProtocol(pattern.protocol ?? urlObj.protocol);
+		if (expectedPort !== urlObj.port) return undefined;
+	}
+
+	const prefix = pattern.pathnamePrefix;
+	if (prefix === "/") {
+		if (urlObj.pathname.startsWith("//")) return undefined;
+		if (pattern.pathMode === "segments") {
+			return isNonEmptyPathSegments(urlObj.pathname)
+				? urlObj.pathname
+				: undefined;
+		}
+		return urlObj.pathname;
+	}
+	if (urlObj.pathname === prefix) {
+		return pattern.pathMode === "catch-all-required" ? undefined : "";
+	}
+	if (urlObj.pathname.startsWith(`${prefix}/`)) {
+		const suffix = urlObj.pathname.slice(prefix.length);
+		if (suffix.startsWith("//")) return undefined;
+		if (
+			pattern.pathMode === "segments" &&
+			!isNonEmptyPathSegments(suffix)
+		) {
+			return undefined;
+		}
+		return suffix;
+	}
+	return undefined;
+}
+
+/**
+ * @param {string} pathname
+ * @returns {boolean}
+ */
+function isNonEmptyPathSegments(pathname) {
+	return pathname.length > 1 && !pathname.endsWith("/") && !pathname.includes("//");
+}
+
+/**
+ * URLPattern treats the default port as empty in URL instances.
+ *
+ * @param {string} protocol
+ * @returns {string}
+ */
+function defaultPortForProtocol(protocol) {
+	if (protocol === "http:") return "";
+	if (protocol === "https:") return "";
+	return "";
+}
+
+/**
+ * @param {FastPathPattern} pattern
+ * @param {string} suffix
+ * @param {URL} source
+ * @returns {URL}
+ */
+function applyFastPathPattern(pattern, suffix, source) {
+	const localized = new URL(source.href);
+	if (pattern.protocol !== undefined) localized.protocol = pattern.protocol;
+	if (pattern.hostname !== undefined) {
+		localized.hostname = pattern.hostname;
+		localized.port =
+			pattern.port ?? defaultPortForProtocol(localized.protocol);
+	}
+	localized.pathname = joinFastPathPrefix(pattern.pathnamePrefix, suffix);
+	return localized;
+}
+
+/**
+ * @param {string} prefix
+ * @param {string} suffix
+ * @returns {string}
+ */
+function joinFastPathPrefix(prefix, suffix) {
+	if (prefix === "/") return suffix === "" ? "/" : suffix;
+	if (suffix === "") return prefix;
+	return `${prefix}${suffix.startsWith("/") ? suffix : `/${suffix}`}`;
 }

--- a/src/services/file-handling/write-output.bench.ts
+++ b/src/services/file-handling/write-output.bench.ts
@@ -1,0 +1,29 @@
+import { bench } from "vitest";
+import memfs from "memfs";
+import { writeOutput } from "./write-output.js";
+type NodeFs = typeof import("node:fs/promises");
+
+const output = Object.fromEntries(
+	Array.from({ length: 2_000 }, (_, index) => [
+		`messages/bundle-${index}.js`,
+		`export const m${index} = ${JSON.stringify("Hello world")}`,
+	])
+);
+
+bench("write 2,000 generated message modules", async () => {
+	const volume = memfs.Volume.fromJSON({});
+	const fsp = memfs.createFsFromVolume(volume).promises as unknown as NodeFs;
+	await writeOutput({ directory: "/output", output, fs: fsp });
+});
+
+bench("rewrite one of 2,000 generated message modules", async () => {
+	const volume = memfs.Volume.fromJSON({});
+	const fsp = memfs.createFsFromVolume(volume).promises as unknown as NodeFs;
+	const hashes = await writeOutput({ directory: "/output", output, fs: fsp });
+	await writeOutput({
+		directory: "/output",
+		output: { ...output, "messages/bundle-0.js": "changed" },
+		fs: fsp,
+		previousOutputHashes: hashes,
+	});
+});

--- a/src/services/file-handling/write-output.test.ts
+++ b/src/services/file-handling/write-output.test.ts
@@ -109,6 +109,37 @@ test("should write again if the output has changed", async () => {
 	expect(writeFileSpy).toHaveBeenCalledTimes(2);
 });
 
+test("should only create directories for files that changed", async () => {
+	const { writeOutput } = await import("./write-output.js");
+	const fs = mockFs({});
+	const mkdirSpy = vi.spyOn(fs, "mkdir");
+
+	const hashes = await writeOutput({
+		directory: "/output",
+		output: {
+			"messages/first.js": "first",
+			"messages/second.js": "second",
+		},
+		fs,
+	});
+	mkdirSpy.mockClear();
+
+	await writeOutput({
+		directory: "/output",
+		output: {
+			"messages/first.js": "changed",
+			"messages/second.js": "second",
+		},
+		fs,
+		previousOutputHashes: hashes,
+	});
+
+	expect(mkdirSpy).toHaveBeenCalledTimes(1);
+	expect(mkdirSpy).toHaveBeenCalledWith("/output/messages", {
+		recursive: true,
+	});
+});
+
 test("should write files if output has partially changed", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({});

--- a/src/services/file-handling/write-output.ts
+++ b/src/services/file-handling/write-output.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { createHash } from "node:crypto";
 import type nodeFs from "node:fs/promises";
 
 export async function writeOutput(args: {
@@ -11,7 +12,7 @@ export async function writeOutput(args: {
 	const currentOutputHashes = await hashOutput(args.output, args.directory);
 
 	// if the output hasn't changed, don't write it
-	const changedFiles = new Set();
+	const changedFiles = new Set<string>();
 
 	for (const [filePath, hash] of Object.entries(currentOutputHashes)) {
 		if (args.previousOutputHashes?.[filePath] !== hash) {
@@ -39,8 +40,6 @@ export async function writeOutput(args: {
 	// and re-enabled because of https://github.com/opral/inlang-paraglide-js/issues/420
 	if (args.cleanDirectory) {
 		await args.fs.rm(args.directory, { recursive: true, force: true });
-	} else {
-		await args.fs.mkdir(args.directory, { recursive: true });
 	}
 	// Delete files that have been removed
 	// ignore if cleanDirectory is true because the directory will be cleaned anyway
@@ -48,13 +47,20 @@ export async function writeOutput(args: {
 		await deleteRemovedFiles(args.fs, args.directory, filesToDelete);
 	}
 
-	//Create missing directories inside the output directory
+	// Create only the directories needed by files that are about to be written.
+	// On incremental compiles, `output` can contain thousands of unchanged
+	// message modules; creating every parent directory again adds avoidable
+	// filesystem work even though only a handful of files changed.
+	const directoriesToCreate = new Set<string>();
+	for (const filePath of changedFiles) {
+		directoriesToCreate.add(
+			path.dirname(path.resolve(args.directory, filePath))
+		);
+	}
 	await Promise.allSettled(
-		Object.keys(args.output).map(async (filePath) => {
-			const fullPath = path.resolve(args.directory, filePath);
-			const directory = path.dirname(fullPath);
-			await args.fs.mkdir(directory, { recursive: true });
-		})
+		Array.from(directoriesToCreate, (directory) =>
+			args.fs.mkdir(directory, { recursive: true })
+		)
 	);
 
 	//Write files
@@ -129,25 +135,20 @@ async function deleteRemovedFiles(
 	}
 }
 
-async function hashString(input: string): Promise<string> {
-	const encoder = new TextEncoder();
-	const data = encoder.encode(input);
-	const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-	const hashArray = Array.from(new Uint8Array(hashBuffer));
-	return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+function hashString(input: string): string {
+	return createHash("sha256").update(input).digest("hex");
 }
 
 async function hashOutput(
 	output: Record<string, string>,
 	outputDirectory: string
 ): Promise<Record<string, string>> {
-	const hashes: Record<string, string> = {};
-	for (const [filePath, fileContent] of Object.entries(output)) {
+	const entries = Object.entries(output).map(([filePath, fileContent]) => {
 		const combinedContent =
 			fileContent + path.resolve(outputDirectory, filePath);
-		hashes[filePath] = await hashString(combinedContent);
-	}
-	return hashes;
+		return [filePath, hashString(combinedContent)] as const;
+	});
+	return Object.fromEntries(entries);
 }
 
 /**


### PR DESCRIPTION
## What changed

- Add a conservative direct matcher for common locale-prefix and static-domain routes using `/:path(.*)?` or `:path*` catch-alls.
- Keep URLPattern as the fallback for custom regexes, dynamic hosts, and all unsupported route shapes.
- Cache the parsed route descriptors and absolute dynamic-protocol URL patterns.
- Add parity tests and a fast-vs-generic benchmark.

## Why

SSR workloads that call `localizeHref` repeatedly were spending substantial CPU time constructing and executing URLPatterns. The user-reported routes are commonly simple locale prefixes and fixed domains, which can be matched with origin and pathname checks.

## Safety

The fast path intentionally does not recognize `:path(.)?`: URLPattern's `(.)` means exactly one character, so broadening it would change semantics. Those routes retain the generic matcher and existing URLPattern cache.

## Measurements

The direct benchmark measured approximately 99 ms for 100k fast-path calls versus 521 ms for the generic URLPattern fallback (~5.3x). Parity checks covered root/path-prefix/static-domain/explicit-port routes and edge paths.

## Validation

- Full stack compile/type checking passed.
- Targeted `localize-href` tests passed (7/7).
- Broader suite: 401 passed, 7 skipped; one unrelated workspace-package resolution failure for `@inlang/paraglide-js/urlpattern-polyfill` in the isolated worktree.
- Oxlint and direct route parity checks passed.

Depends on #745.