### PR TITLE
fix: preserve unchanged one-shot compile outputs

### DIFF
--- a/.changeset/tidy-tools-compile.md
+++ b/.changeset/tidy-tools-compile.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Avoid rewriting unchanged output files during one-shot CLI compilation.

--- a/src/cli/commands/compile/command.test.ts
+++ b/src/cli/commands/compile/command.test.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	for (const listener of process.listeners("SIGINT")) {
 		if (!initialSigintListeners.includes(listener)) {
 			process.removeListener("SIGINT", listener);
@@ -22,6 +23,64 @@ afterEach(async () => {
 	for (const directory of testDirectories) {
 		await rm(directory, { recursive: true, force: true });
 	}
+});
+
+test("compile seeds existing outdir and disables cleaning (#743)", async () => {
+	const testDirectory = await mkdtemp(path.join(tmpdir(), "paraglide-cli-"));
+	testDirectories.push(testDirectory);
+	const outdir = path.join(testDirectory, "output");
+	const { writeOutput } = await import(
+		"../../../services/file-handling/write-output.js"
+	);
+	await writeOutput({
+		directory: outdir,
+		output: {
+			"runtime.js": "export const runtime = true;",
+		},
+		fs: nodeFs,
+	});
+
+	const compileMock = vi.fn().mockResolvedValue({
+		outputHashes: {
+			"runtime.js": "next-hash",
+		},
+	});
+	vi.doMock("../../../compiler/compile.js", () => ({
+		compile: compileMock,
+	}));
+	const exitError = new Error("process.exit");
+	const exitMock = vi.spyOn(process, "exit").mockImplementation(() => {
+		throw exitError;
+	});
+
+	const { compileCommand } = await import("./command.js");
+
+	await expect(
+		compileCommand.parseAsync(
+			[
+				"--project",
+				path.join(testDirectory, "project.inlang"),
+				"--outdir",
+				outdir,
+				"--silent",
+			],
+			{ from: "user" }
+		)
+	).rejects.toBe(exitError);
+
+	expect(compileMock).toHaveBeenCalledTimes(1);
+	expect(compileMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			outdir,
+			cleanOutdir: false,
+			previousCompilation: {
+				outputHashes: {
+					"runtime.js": expect.any(String),
+				},
+			},
+		})
+	);
+	expect(exitMock).toHaveBeenCalledWith(0);
 });
 
 test("compile --watch seeds existing outdir and disables cleaning on first compile (#688)", async () => {

--- a/src/cli/commands/compile/command.ts
+++ b/src/cli/commands/compile/command.ts
@@ -144,7 +144,15 @@ export const compileCommand = new Command()
 				logger.info(`Compiling inlang project ...`);
 
 				try {
-					await compile(compileOptions);
+					const previousCompilation = await seedPreviousCompilationFromOutdir({
+						outdir: compileOptions.outdir,
+					});
+
+					await compile({
+						...compileOptions,
+						previousCompilation,
+						cleanOutdir: false,
+					});
 				} catch (e) {
 					logger.error("Error while compiling inlang project.");
 					logger.error(e);


### PR DESCRIPTION
Closes #743.

## What changed

- seed one-shot CLI compilation from the existing output directory
- disable output-directory cleaning so unchanged generated files are left untouched
- add regression coverage for the non-watch compile path
- add a patch changeset

## Why

The one-shot `paraglide-js compile` path did not reuse output hashes, unlike watch mode and the Vite plugin. It therefore removed and rewrote the entire output directory even when generated content was unchanged, triggering unnecessary watcher reloads.

## Validation

- `pnpm build`
- `pnpm test` (405 passed, 7 skipped)
- three independent reviews: implementation correctness, regression-test quality, and PR readiness; no actionable findings
