### PR TITLE
perf: cache unchanged Vite compilations

### DIFF
--- a/.changeset/cache-vite-compilation.md
+++ b/.changeset/cache-vite-compilation.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Skip unchanged Vite compilations across dev-server restarts by persisting and validating the compiler input cache.

--- a/src/bundler-plugins/unplugin.test.ts
+++ b/src/bundler-plugins/unplugin.test.ts
@@ -208,6 +208,97 @@ test("vite plugin warm-restart writes nothing when inputs unchanged (#659)", asy
 	expect(writeFileSpy).not.toHaveBeenCalled();
 });
 
+// Regression test for https://github.com/opral/paraglide-js/issues/741:
+// a new Vite process should validate the persisted inputs and output instead
+// of loading the project and compiling every message again.
+test("vite plugin skips compile on an unchanged fresh process (#741)", async () => {
+	const actualCompileModule = await vi.importActual<
+		typeof import("../compiler/compile.js")
+	>("../compiler/compile.js");
+	const compileSpy = vi.fn(actualCompileModule.compile);
+	vi.doMock("../compiler/compile.js", () => ({
+		...actualCompileModule,
+		compile: compileSpy,
+	}));
+
+	try {
+		const project = await loadProjectInMemory({
+			blob: await newProject({
+				settings: { baseLocale: "en", locales: ["en", "de"] },
+			}),
+		});
+		const fs = memfs().fs as unknown as typeof import("node:fs");
+		await saveProjectToDirectory({
+			project,
+			path: "/project.inlang",
+			fs: fs.promises,
+		});
+
+		const options = {
+			project: "/project.inlang",
+			outdir: "/test-output",
+			emitReadme: true,
+			fs,
+		};
+		const mockContext = { addWatchFile: () => {} };
+		const startFreshProcess = async () => {
+			vi.resetModules();
+			const { paraglideVitePlugin } =
+				await import("../bundler-plugins/vite.js");
+			const plugin = paraglideVitePlugin(options) as any;
+			await plugin.buildStart?.call(mockContext);
+		};
+
+		await startFreshProcess();
+		expect(compileSpy).toHaveBeenCalledTimes(1);
+
+		// The persisted cache makes the unchanged cold restart skip compile().
+		await startFreshProcess();
+		expect(compileSpy).toHaveBeenCalledTimes(1);
+
+		// A file added beside a tracked project input invalidates the cache.
+		await fs.promises.writeFile("/project.inlang/new-project-input.txt", "new");
+		await startFreshProcess();
+		expect(compileSpy).toHaveBeenCalledTimes(2);
+
+		// Compiler options are part of the cache key.
+		options.emitReadme = false;
+		await startFreshProcess();
+		expect(compileSpy).toHaveBeenCalledTimes(3);
+
+		// Generated output is validated too, so edited output self-repairs.
+		await fs.promises.writeFile("/test-output/runtime.js", "tampered");
+		await startFreshProcess();
+		expect(compileSpy).toHaveBeenCalledTimes(4);
+		expect(
+			await fs.promises.readFile("/test-output/runtime.js", "utf8")
+		).not.toBe("tampered");
+
+		// A compiler version change invalidates the persisted cache.
+		const cacheDirectory = "/project.inlang/cache/paraglide-js";
+		for (const cacheFile of await fs.promises.readdir(cacheDirectory)) {
+			const cachePath = `${cacheDirectory}/${cacheFile}`;
+			const cache = JSON.parse(await fs.promises.readFile(cachePath, "utf8"));
+			cache.compilerVersion = "0.0.0-stale";
+			await fs.promises.writeFile(cachePath, JSON.stringify(cache));
+		}
+		await startFreshProcess();
+		expect(compileSpy).toHaveBeenCalledTimes(5);
+
+		// A syntactically valid but malformed cache is treated as a miss.
+		for (const cacheFile of await fs.promises.readdir(cacheDirectory)) {
+			const cachePath = `${cacheDirectory}/${cacheFile}`;
+			const cache = JSON.parse(await fs.promises.readFile(cachePath, "utf8"));
+			cache.outputHashes = null;
+			await fs.promises.writeFile(cachePath, JSON.stringify(cache));
+		}
+		await startFreshProcess();
+		expect(compileSpy).toHaveBeenCalledTimes(6);
+	} finally {
+		vi.doUnmock("../compiler/compile.js");
+	}
+});
+
 // Regression test for https://github.com/opral/paraglide-js/issues/693:
 // `vite build` fires buildStart once per environment (client, ssr) and each
 // run used to do a full compile() — project loading + message compilation —

--- a/src/bundler-plugins/unplugin.ts
+++ b/src/bundler-plugins/unplugin.ts
@@ -1,9 +1,10 @@
 import type { UnpluginFactory } from "unplugin";
 import { compile, type CompilationResult } from "../compiler/compile.js";
-import { relative } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { createHash } from "node:crypto";
 import nodeFs from "node:fs";
 import { Logger } from "../services/logger/index.js";
+import { ENV_VARIABLES } from "../services/env-variables/index.js";
 import type { CompilerOptions } from "../compiler/compiler-options.js";
 import {
 	createTrackedFs,
@@ -16,6 +17,25 @@ import { seedPreviousCompilationFromOutdir } from "../compiler/seed-previous-com
 const PLUGIN_NAME = "unplugin-paraglide-js";
 
 const logger = new Logger();
+
+const PERSISTENT_CACHE_VERSION = 1;
+
+type PersistentCompilationCache = {
+	version: typeof PERSISTENT_CACHE_VERSION;
+	compilerVersion: string;
+	inputsDigest: string;
+	readFiles: string[];
+	outputHashes: Record<string, string>;
+};
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.values(value).every((entry) => typeof entry === "string")
+	);
+}
 
 /**
  * Default isServer which differs per bundler.
@@ -71,6 +91,20 @@ function withoutCleanOutdir(
 	return compileArgs;
 }
 
+function getCompilerConfig(
+	args: CompilerOptions,
+	outputStructure: NonNullable<CompilerOptions["outputStructure"]>
+) {
+	const { fs: _fs, ...serializableArgs } = args;
+	void _fs;
+	return {
+		...serializableArgs,
+		outputStructure,
+		isServer,
+		compilerVersion: ENV_VARIABLES.PARJS_PACKAGE_VERSION,
+	};
+}
+
 /**
  * Hashes the files (and directory listings) the last compilation read,
  * together with the options that affect the output. Returns `undefined`
@@ -102,11 +136,7 @@ async function computeInputsDigest(
 	const fsp = (args.fs ?? nodeFs).promises;
 	const hash = createHash("sha256");
 	try {
-		const { fs: _fs, ...serializableArgs } = args;
-		void _fs;
-		hash.update(
-			JSON.stringify({ ...serializableArgs, outputStructure, isServer })
-		);
+		hash.update(JSON.stringify(getCompilerConfig(args, outputStructure)));
 		for (const directoryPath of [...targets.directories].sort()) {
 			const entries = await fsp
 				.readdir(directoryPath)
@@ -139,6 +169,154 @@ async function computeInputsDigest(
 	return hash.digest("hex");
 }
 
+function getPersistentCachePath(
+	args: CompilerOptions,
+	outputStructure: NonNullable<CompilerOptions["outputStructure"]>
+): string {
+	const absoluteOutdir = resolve(process.cwd(), args.outdir);
+	const cacheKey = createHash("sha256")
+		.update(
+			JSON.stringify({
+				absoluteOutdir,
+				compilerConfig: getCompilerConfig(args, outputStructure),
+			})
+		)
+		.digest("hex")
+		.slice(0, 16);
+	return resolve(
+		process.cwd(),
+		args.project,
+		"cache",
+		"paraglide-js",
+		`${cacheKey}.json`
+	);
+}
+
+async function readPersistentCache(
+	args: CompilerOptions,
+	outputStructure: NonNullable<CompilerOptions["outputStructure"]>
+): Promise<PersistentCompilationCache | undefined> {
+	const fsp = (args.fs ?? nodeFs).promises;
+	try {
+		const parsed = JSON.parse(
+			await fsp.readFile(getPersistentCachePath(args, outputStructure), "utf8")
+		) as Partial<PersistentCompilationCache>;
+		if (
+			parsed.version !== PERSISTENT_CACHE_VERSION ||
+			parsed.compilerVersion !== ENV_VARIABLES.PARJS_PACKAGE_VERSION ||
+			typeof parsed.inputsDigest !== "string" ||
+			!Array.isArray(parsed.readFiles) ||
+			parsed.readFiles.some((file) => typeof file !== "string") ||
+			!isStringRecord(parsed.outputHashes)
+		) {
+			return undefined;
+		}
+		return parsed as PersistentCompilationCache;
+	} catch {
+		return undefined;
+	}
+}
+
+async function preparePersistentCacheDirectory(
+	args: CompilerOptions,
+	outputStructure: NonNullable<CompilerOptions["outputStructure"]>
+): Promise<void> {
+	try {
+		await (args.fs ?? nodeFs).promises.mkdir(
+			dirname(getPersistentCachePath(args, outputStructure)),
+			{ recursive: true }
+		);
+	} catch {
+		// The cache is an optimization. Read-only projects must still compile.
+	}
+}
+
+async function writePersistentCache(
+	state: PluginState,
+	args: CompilerOptions,
+	outputStructure: NonNullable<CompilerOptions["outputStructure"]>
+): Promise<void> {
+	if (
+		state.previousInputsDigest === undefined ||
+		state.previousCompilation?.outputHashes === undefined
+	) {
+		return;
+	}
+	const cachePath = getPersistentCachePath(args, outputStructure);
+	const cache: PersistentCompilationCache = {
+		version: PERSISTENT_CACHE_VERSION,
+		compilerVersion: ENV_VARIABLES.PARJS_PACKAGE_VERSION,
+		inputsDigest: state.previousInputsDigest,
+		readFiles: [...state.readFiles].sort(),
+		outputHashes: state.previousCompilation.outputHashes,
+	};
+	const fsp = (args.fs ?? nodeFs).promises;
+	try {
+		await fsp.mkdir(dirname(cachePath), { recursive: true });
+		await fsp.writeFile(cachePath, JSON.stringify(cache));
+	} catch {
+		// The cache is an optimization. Read-only projects must still compile.
+	}
+}
+
+function outputHashesMatch(
+	left: Record<string, string> | undefined,
+	right: Record<string, string>
+): boolean {
+	if (left === undefined) return false;
+	const leftEntries = Object.entries(left);
+	const rightEntries = Object.entries(right);
+	if (leftEntries.length !== rightEntries.length) return false;
+	return leftEntries.every(([file, hash]) => right[file] === hash);
+}
+
+async function restorePersistentCache(args: {
+	state: PluginState;
+	compilerOptions: CompilerOptions;
+	outputStructure: NonNullable<CompilerOptions["outputStructure"]>;
+}): Promise<boolean> {
+	const cached = await readPersistentCache(
+		args.compilerOptions,
+		args.outputStructure
+	);
+	if (cached === undefined) return false;
+
+	const cachedReadFiles = new Set<string>();
+	for (const file of cached.readFiles) {
+		cachedReadFiles.add(file);
+	}
+	const validationState: PluginState = {
+		...args.state,
+		readFiles: cachedReadFiles,
+		clearReadFiles: () => cachedReadFiles.clear(),
+	};
+	const [inputsDigest, previousCompilation] = await Promise.all([
+		computeInputsDigest(
+			validationState,
+			args.compilerOptions,
+			args.outputStructure
+		),
+		seedPreviousCompilationFromOutdir({
+			outdir: args.compilerOptions.outdir,
+			fs: args.compilerOptions.fs?.promises,
+		}),
+	]);
+	if (
+		inputsDigest !== cached.inputsDigest ||
+		!outputHashesMatch(previousCompilation?.outputHashes, cached.outputHashes)
+	) {
+		return false;
+	}
+
+	args.state.clearReadFiles();
+	for (const file of cachedReadFiles) {
+		args.state.readFiles.add(file);
+	}
+	args.state.previousCompilation = previousCompilation;
+	args.state.previousInputsDigest = inputsDigest;
+	return true;
+}
+
 function rethrowUnlessEnoent(error: unknown): undefined {
 	if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
 		return undefined;
@@ -160,6 +338,22 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => {
 				args.outputStructure ??
 				(isProduction ? "message-modules" : "locale-modules");
 			try {
+				// Stabilize project directory listings before the first digest. The
+				// ignored cache directory must not invalidate the cache that creates it.
+				await preparePersistentCacheDirectory(args, outputStructure);
+				if (
+					state.previousCompilation === undefined &&
+					(await restorePersistentCache({
+						state,
+						compilerOptions: args,
+						outputStructure,
+					}))
+				) {
+					logger.info(
+						`Compilation skipped — inputs unchanged (${outputStructure})`
+					);
+					return;
+				}
 				// `vite build` calls buildStart once per environment (client, ssr).
 				// Skip the expensive compile when the inputs haven't changed.
 				if (state.previousCompilation && state.previousInputsDigest) {
@@ -199,6 +393,7 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => {
 					args,
 					outputStructure
 				);
+				await writePersistentCache(state, args, outputStructure);
 				logger.success(`Compilation complete (${outputStructure})`);
 			} catch (error) {
 				state.previousInputsDigest = undefined;
@@ -260,6 +455,7 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => {
 					args,
 					outputStructure
 				);
+				await writePersistentCache(state, args, outputStructure);
 
 				logger.success(`Re-compilation complete (${outputStructure})`);
 


### PR DESCRIPTION
Closes #741.

## What changed

- persist the Vite compiler input digest, tracked project files, compiler version, and generated-output hashes under `project.inlang/cache/paraglide-js`
- skip `compile()` on a fresh Vite process when inputs, output-affecting options, compiler version, and generated files are unchanged
- validate generated output before using the cache so missing or edited files trigger a repairing compile
- treat missing, stale, or malformed cache records as cache misses
- add a patch changeset

## Scope

This targets the common unchanged `vite dev` restart path. Async/lazy compilation and write parallelization remain outside this PR.

## Validation

- independent correctness/security, testing, and architecture/performance reviews; no blocking findings after fixes
- `pnpm run build`
- `pnpm run test` — 405 passed, 7 skipped
- `pnpm exec oxlint --config .oxlintrc.json src/bundler-plugins/unplugin.ts src/bundler-plugins/unplugin.test.ts`
- `git diff --check`