### PR TITLE
docs: clarify localized root trailing slashes

### DIFF
--- a/docs/i18n-routing.md
+++ b/docs/i18n-routing.md
@@ -111,6 +111,13 @@ compile({
 	strategy: ["url", "cookie"],
 	urlPatterns: [
 		{
+			pattern: "/",
+			localized: [
+				["de", "/de"],
+				["en", "/"],
+			],
+		},
+		{
 			pattern: "/:path(.*)?",
 			localized: [
 				["de", "/de/:path(.*)?"],
@@ -122,7 +129,11 @@ compile({
 });
 ```
 
-**Why the wildcard pattern always resolves**: The pattern `/:path(.*)?` matches **any** path. When a user visits `/about` (without a locale prefix), it matches the English pattern and resolves to `en`. This is also the default behavior if you don't specify `urlPatterns` at all.
+The exact root rule generates `/de` and `/de#section` instead of `/de/` and
+`/de/#section`. It must appear before the wildcard because the first matching
+pattern wins.
+
+**Why the wildcard pattern always resolves**: The pattern `/:path(.*)?` matches **any path not already handled by the exact root rule**. When a user visits `/about` (without a locale prefix), it matches the English pattern and resolves to `en`. Paraglide's built-in default routing also uses a wildcard when you don't specify `urlPatterns`.
 
 > [!NOTE]
 > `extractLocaleFromUrl()` is case-insensitive only for Paraglide's built-in default routing mode, where the locale is read from the first path segment and canonicalized (so `/DE/about` resolves to `de`). Once you provide custom `urlPatterns`, matching follows normal `URLPattern` semantics instead, so path casing must match your configured patterns exactly.
@@ -155,7 +166,9 @@ compile({
 });
 ```
 
-The dedicated root pattern prevents redirect loops on the homepage.
+The dedicated root pattern generates `/en` and `/fr` instead of `/en/` and
+`/fr/`. It also prevents redirect loops and unnecessary navigation to a
+non-canonical homepage URL.
 
 ### Routes without locale prefix
 
@@ -616,6 +629,16 @@ This is especially important for path-based localization where one locale has a 
 
 ### Trailing slashes
 
-URLPattern treats `/about` and `/about/` as different paths. To handle both consistently, your framework or server should normalize trailing slashes before the middleware runs. Most frameworks (Next.js, SvelteKit, Astro) handle this automatically.
+URLPattern treats `/about` and `/about/` as different paths. Your framework or
+server should choose and enforce a consistent canonical form for incoming URLs.
+Most frameworks provide trailing-slash handling for this.
+
+Framework normalization does not change URLs produced by `localizeHref()` or
+`localizeUrl()`. If Paraglide generates `/de/` while your framework considers
+`/de` canonical, following a link such as `/de/#section` can cause an
+unnecessary navigation or redirect instead of a fragment-only update. Use an
+exact root pattern before the wildcard, as shown in
+[Locale prefixing](#locale-prefixing), to make the generated URL match your
+framework's canonical URL.
 
 If you're seeing redirect loops involving trailing slashes, check your framework's trailing slash configuration.


### PR DESCRIPTION
## Summary

- recommend an exact root URL pattern before the wildcard pattern
- document that this generates /de and /de#section instead of /de/ and /de/#section
- clarify that framework normalization does not change URLs generated by localizeHref() or localizeUrl()
- explain how non-canonical localized root links can cause redirects or unnecessary navigation

Related to #473 and #480.

## Verification

- pnpm prettier docs/i18n-routing.md --check
- git diff --check origin/main...HEAD
