### PR TITLE
Add trailing slash configuration for localized URLs

### DIFF
--- a/.changeset/tidy-trailing-slashes.md
+++ b/.changeset/tidy-trailing-slashes.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Add an opt-in `trailingSlash` compiler option for canonicalizing localized URLs.

--- a/docs-api/compiler-options.md
+++ b/docs-api/compiler-options.md
@@ -40,7 +40,7 @@ The output will look like this:
 
 > `optional` **cleanOutdir**: `boolean`
 
-Defined in: [compiler-options.ts:392](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:400](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 Whether to clean the output directory before writing the new files.
 
@@ -111,7 +111,7 @@ The name of the cookie to use for the cookie strategy.
 
 > `optional` **disableAsyncLocalStorage**: `boolean`
 
-Defined in: [compiler-options.ts:321](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:329](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 Replaces AsyncLocalStorage with a synchronous implementation.
 
@@ -128,7 +128,7 @@ one request could leak into another concurrent request.
 
 > `optional` **emitGitIgnore**: `boolean`
 
-Defined in: [compiler-options.ts:335](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:343](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 If `emitGitIgnore` is set to `true` a `.gitignore` file will be emitted in the output directory. Defaults to `true`.
 
@@ -303,7 +303,7 @@ https://github.com/opral/paraglide-js/issues/88#issuecomment-3634754638
 
 > `optional` **fs**: `any`
 
-Defined in: [compiler-options.ts:399](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:407](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 The file system to use. Defaults to `await import('node:fs')`.
 
@@ -313,7 +313,7 @@ Useful for testing the paraglide compiler by mocking the fs.
 
 > `optional` **includeEslintDisableComment**: `boolean`
 
-Defined in: [compiler-options.ts:308](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:316](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 Whether to include an eslint-disable comment at the top of each .js file.
 
@@ -382,7 +382,7 @@ await compile({
 
 > `optional` **outputStructure**: `"locale-modules"` \| `"message-modules"`
 
-Defined in: [compiler-options.ts:386](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:394](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 The `outputStructure` defines how modules are structured in the output.
 
@@ -502,6 +502,18 @@ Custom strategies with the pattern `custom-[A-Za-z0-9]+` are supported.
 ```ts
 ["cookie", "globalVariable", "baseLocale"]
 ```
+
+#### trailingSlash?
+
+> `optional` **trailingSlash**: `"always"` \| `"never"`
+
+Defined in: [compiler-options.ts:310](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+
+Controls trailing slash canonicalization for localized URLs.
+
+Canonicalization happens before URL pattern matching and after URL
+localization. If omitted, Paraglide keeps its existing trailing slash
+behavior.
 
 #### urlPatterns?
 

--- a/docs-api/runtime/type/-internal-.md
+++ b/docs-api/runtime/type/-internal-.md
@@ -16,7 +16,7 @@ Effective request URL to use for route matching and locale detection with the UR
 
 ## ShouldRedirectClientInput
 
-Defined in: [runtime/should-redirect.js:17](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:18](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 ### Properties
 
@@ -24,25 +24,25 @@ Defined in: [runtime/should-redirect.js:17](https://github.com/opral/paraglide-j
 
 > `optional` **locale**: `string`
 
-Defined in: [runtime/should-redirect.js:20](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:21](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 #### request?
 
 > `optional` **request**: `undefined`
 
-Defined in: [runtime/should-redirect.js:18](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:19](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 #### url?
 
 > `optional` **url**: `string` \| `URL`
 
-Defined in: [runtime/should-redirect.js:19](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:20](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 ***
 
 ## ShouldRedirectResult
 
-Defined in: [runtime/should-redirect.js:24](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:25](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 ### Properties
 
@@ -50,13 +50,13 @@ Defined in: [runtime/should-redirect.js:24](https://github.com/opral/paraglide-j
 
 > **locale**: `string`
 
-Defined in: [runtime/should-redirect.js:26](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:27](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 #### redirectUrl
 
 > **redirectUrl**: `undefined` \| `URL`
 
-Defined in: [runtime/should-redirect.js:27](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:28](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 Destination URL when a redirect is required.
 
@@ -64,7 +64,7 @@ Destination URL when a redirect is required.
 
 > **shouldRedirect**: `boolean`
 
-Defined in: [runtime/should-redirect.js:25](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:26](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 Indicates whether the consumer should perform a redirect.
 
@@ -72,7 +72,7 @@ Indicates whether the consumer should perform a redirect.
 
 ## ShouldRedirectServerInput
 
-Defined in: [runtime/should-redirect.js:12](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:13](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 ### Properties
 
@@ -80,7 +80,7 @@ Defined in: [runtime/should-redirect.js:12](https://github.com/opral/paraglide-j
 
 > `optional` **effectiveRequestUrl**: `string` \| `URL`
 
-Defined in: [runtime/should-redirect.js:14](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:15](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 Effective request URL to use for route matching, locale detection with the URL strategy, and redirect targets.
 
@@ -88,13 +88,13 @@ Effective request URL to use for route matching, locale detection with the URL s
 
 > `optional` **locale**: `string`
 
-Defined in: [runtime/should-redirect.js:15](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:16](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 #### request
 
 > **request**: `Request`
 
-Defined in: [runtime/should-redirect.js:13](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:14](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 ***
 
@@ -180,7 +180,7 @@ Defined in: [runtime/type-definitions.js:9](https://github.com/opral/paraglide-j
 
 > **ParaglideAsyncLocalStorage**\<\> = `object`
 
-Defined in: [runtime/variables.js:67](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:74](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
 
 ### Type Parameters
 
@@ -254,7 +254,7 @@ Defined in: [runtime/set-locale.js:36](https://github.com/opral/paraglide-js/tre
 
 > **ShouldRedirectInput**\<\> = [`ShouldRedirectServerInput`](#shouldredirectserverinput) \| [`ShouldRedirectClientInput`](#shouldredirectclientinput)
 
-Defined in: [runtime/should-redirect.js:22](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:23](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 ### Type Parameters
 
@@ -298,7 +298,7 @@ Defined in: [runtime/variables.js:22](https://github.com/opral/paraglide-js/tree
 
 > `const` **disableAsyncLocalStorage**: `false` = `false`
 
-Defined in: [runtime/variables.js:80](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:99](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
 
 ***
 
@@ -306,7 +306,7 @@ Defined in: [runtime/variables.js:80](https://github.com/opral/paraglide-js/tree
 
 > `const` **experimentalMiddlewareLocaleSplitting**: `false` = `false`
 
-Defined in: [runtime/variables.js:82](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:101](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
 
 ***
 
@@ -314,7 +314,7 @@ Defined in: [runtime/variables.js:82](https://github.com/opral/paraglide-js/tree
 
 > `const` **experimentalStaticLocale**: `undefined` \| `string` = `undefined`
 
-Defined in: [runtime/variables.js:87](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:106](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
 
 ***
 
@@ -322,7 +322,7 @@ Defined in: [runtime/variables.js:87](https://github.com/opral/paraglide-js/tree
 
 > `const` **isServer**: `boolean`
 
-Defined in: [runtime/variables.js:84](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:103](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
 
 ***
 
@@ -374,7 +374,7 @@ Route-level strategy overrides.
 
 > **serverAsyncLocalStorage**: `undefined` \| [`ParaglideAsyncLocalStorage`](#paraglideasynclocalstorage) = `undefined`
 
-Defined in: [runtime/variables.js:78](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:85](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
 
 Server side async local storage that is set by `serverMiddleware()`.
 
@@ -388,6 +388,16 @@ rendering context without effecting other requests.
 > `const` **strategy**: (`` `custom-${string}` `` \| `"cookie"` \| `"baseLocale"` \| `"globalVariable"` \| `"url"` \| `"preferredLanguage"` \| `"localStorage"`)[]
 
 Defined in: [runtime/variables.js:36](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+
+***
+
+## trailingSlash
+
+> `const` **trailingSlash**: `undefined` \| `"always"` \| `"never"` = `undefined`
+
+Defined in: [runtime/variables.js:63](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+
+Controls trailing slash canonicalization for localized URLs.
 
 ***
 
@@ -570,7 +580,7 @@ which provides more precise control over URL handling.
 
 > **deLocalizeUrl**(`url`): `URL`
 
-Defined in: [runtime/localize-url.js:189](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/localize-url.js)
+Defined in: [runtime/localize-url.js:201](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/localize-url.js)
 
 Low-level URL de-localization function, primarily used in server contexts.
 
@@ -804,7 +814,7 @@ The extracted locale.
 
 > **extractLocaleFromUrl**(`url`): `undefined` \| `string`
 
-Defined in: [runtime/extract-locale-from-url.js:29](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/extract-locale-from-url.js)
+Defined in: [runtime/extract-locale-from-url.js:31](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/extract-locale-from-url.js)
 
 Extracts the locale from a given URL using native URLPattern.
 
@@ -832,7 +842,7 @@ The extracted locale, or undefined if no locale is found.
 
 > **generateStaticLocalizedUrls**(`urls`): `URL`[]
 
-Defined in: [runtime/generate-static-localized-urls.js:52](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/generate-static-localized-urls.js)
+Defined in: [runtime/generate-static-localized-urls.js:55](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/generate-static-localized-urls.js)
 
 Generates localized URL variants for all provided URLs based on your configured locales and URL patterns.
 
@@ -930,11 +940,28 @@ if (getLocale() === 'de') {
 
 ***
 
+## getServerAsyncLocalStorage()
+
+> **getServerAsyncLocalStorage**(): `undefined` \| [`ParaglideAsyncLocalStorage`](#paraglideasynclocalstorage)
+
+Defined in: [runtime/variables.js:95](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+
+Returns the current server-side async local storage instance.
+
+Accessing the mutable value through a function keeps it observable when
+module interceptors wrap exported bindings and snapshot their initial value.
+
+### Returns
+
+`undefined` \| [`ParaglideAsyncLocalStorage`](#paraglideasynclocalstorage)
+
+***
+
 ## getStrategyForUrl()
 
 > **getStrategyForUrl**(`url`): (`` `custom-${string}` `` \| `"cookie"` \| `"baseLocale"` \| `"globalVariable"` \| `"url"` \| `"preferredLanguage"` \| `"localStorage"`)[]
 
-Defined in: runtime/route-strategy.js:60
+Defined in: [runtime/route-strategy.js:64](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/route-strategy.js)
 
 Returns the strategy to use for a specific URL.
 
@@ -1008,7 +1035,7 @@ by `overwriteGetUrlOrigin()`.
 
 > **isExcludedByRouteStrategy**(`url`): `boolean`
 
-Defined in: runtime/route-strategy.js:78
+Defined in: [runtime/route-strategy.js:82](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/route-strategy.js)
 
 Returns whether the given URL is excluded from middleware i18n processing.
 
@@ -1129,7 +1156,7 @@ which provides more precise control over URL handling.
 
 > **localizeUrl**(`url`, `options?`): `URL`
 
-Defined in: [runtime/localize-url.js:55](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/localize-url.js)
+Defined in: [runtime/localize-url.js:58](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/localize-url.js)
 
 Lower-level URL localization function, primarily used in server contexts.
 
@@ -1263,7 +1290,7 @@ The new implementation for `getUrlOrigin()`.
 
 > **overwriteServerAsyncLocalStorage**(`value`): `void`
 
-Defined in: [runtime/variables.js:99](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:118](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/variables.js)
 
 Sets the server side async local storage.
 
@@ -1371,7 +1398,7 @@ setLocale('en', { reload: false });
 
 > **shouldRedirect**(`input?`): `Promise`\<[`ShouldRedirectResult`](#shouldredirectresult)\>
 
-Defined in: [runtime/should-redirect.js:83](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
+Defined in: [runtime/should-redirect.js:84](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/should-redirect.js)
 
 Determines whether a redirect is required to align the current URL with the active locale.
 

--- a/docs-api/runtime/type/README.md
+++ b/docs-api/runtime/type/README.md
@@ -16,7 +16,7 @@ The Paraglide runtime API.
 
 > **assertIsLocale**: [`assertIsLocale`](-internal-.md#assertislocale)
 
-Defined in: [runtime/type.ts:26](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:28](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### baseLocale
 
@@ -40,127 +40,133 @@ Defined in: [runtime/type.ts:9](https://github.com/opral/paraglide-js/tree/main/
 
 > **defineCustomClientStrategy**: [`defineCustomClientStrategy`](-internal-.md#definecustomclientstrategy)
 
-Defined in: [runtime/type.ts:44](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:46](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### defineCustomServerStrategy
 
 > **defineCustomServerStrategy**: [`defineCustomServerStrategy`](-internal-.md#definecustomserverstrategy)
 
-Defined in: [runtime/type.ts:43](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:45](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### deLocalizeHref
 
 > **deLocalizeHref**: [`deLocalizeHref`](-internal-.md#delocalizehref)
 
-Defined in: [runtime/type.ts:29](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:31](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### deLocalizeUrl
 
 > **deLocalizeUrl**: [`deLocalizeUrl`](-internal-.md#delocalizeurl)
 
-Defined in: [runtime/type.ts:31](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:33](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### disableAsyncLocalStorage
 
 > **disableAsyncLocalStorage**: [`disableAsyncLocalStorage`](-internal-.md#disableasynclocalstorage)
 
-Defined in: [runtime/type.ts:12](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:13](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### experimentalMiddlewareLocaleSplitting
 
 > **experimentalMiddlewareLocaleSplitting**: [`experimentalMiddlewareLocaleSplitting`](-internal-.md#experimentalmiddlewarelocalesplitting)
 
-Defined in: [runtime/type.ts:14](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:16](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### experimentalStaticLocale
 
 > **experimentalStaticLocale**: [`experimentalStaticLocale`](-internal-.md#experimentalstaticlocale)
 
-Defined in: [runtime/type.ts:16](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:18](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromCookie
 
 > **extractLocaleFromCookie**: [`extractLocaleFromCookie`](-internal-.md#extractlocalefromcookie)
 
-Defined in: [runtime/type.ts:36](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:38](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromHeader
 
 > **extractLocaleFromHeader**: [`extractLocaleFromHeader`](-internal-.md#extractlocalefromheader)
 
-Defined in: [runtime/type.ts:37](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:39](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromNavigator
 
 > **extractLocaleFromNavigator**: [`extractLocaleFromNavigator`](-internal-.md#extractlocalefromnavigator)
 
-Defined in: [runtime/type.ts:38](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:40](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromRequest
 
 > **extractLocaleFromRequest**: [`extractLocaleFromRequest`](-internal-.md#extractlocalefromrequest)
 
-Defined in: [runtime/type.ts:34](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:36](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromRequestAsync
 
 > **extractLocaleFromRequestAsync**: [`extractLocaleFromRequestAsync`](-internal-.md#extractlocalefromrequestasync)
 
-Defined in: [runtime/type.ts:35](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:37](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromUrl
 
 > **extractLocaleFromUrl**: [`extractLocaleFromUrl`](-internal-.md#extractlocalefromurl)
 
-Defined in: [runtime/type.ts:33](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:35](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### generateStaticLocalizedUrls
 
 > **generateStaticLocalizedUrls**: [`generateStaticLocalizedUrls`](-internal-.md#generatestaticlocalizedurls)
 
-Defined in: [runtime/type.ts:39](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:41](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### getLocale
 
 > **getLocale**: [`getLocale`](-internal-.md#getlocale-2)
 
-Defined in: [runtime/type.ts:17](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:19](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+
+#### getServerAsyncLocalStorage
+
+> **getServerAsyncLocalStorage**: [`getServerAsyncLocalStorage`](-internal-.md#getserverasynclocalstorage)
+
+Defined in: [runtime/type.ts:15](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### getStrategyForUrl
 
 > **getStrategyForUrl**: [`getStrategyForUrl`](-internal-.md#getstrategyforurl)
 
-Defined in: [runtime/type.ts:41](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:43](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### getTextDirection
 
 > **getTextDirection**: [`getTextDirection`](-internal-.md#gettextdirection)
 
-Defined in: [runtime/type.ts:18](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:20](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### getUrlOrigin
 
 > **getUrlOrigin**: [`getUrlOrigin`](-internal-.md#geturlorigin)
 
-Defined in: [runtime/type.ts:20](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:22](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### isExcludedByRouteStrategy
 
 > **isExcludedByRouteStrategy**: [`isExcludedByRouteStrategy`](-internal-.md#isexcludedbyroutestrategy)
 
-Defined in: [runtime/type.ts:42](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:44](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### isLocale
 
 > **isLocale**: [`isLocale`](-internal-.md#islocale)
 
-Defined in: [runtime/type.ts:27](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:29](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### isServer
 
 > **isServer**: [`isServer`](-internal-.md#isserver)
 
-Defined in: [runtime/type.ts:15](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:17](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### locales
 
@@ -172,37 +178,37 @@ Defined in: [runtime/type.ts:6](https://github.com/opral/paraglide-js/tree/main/
 
 > **localizeHref**: [`localizeHref`](-internal-.md#localizehref)
 
-Defined in: [runtime/type.ts:28](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:30](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### localizeUrl
 
 > **localizeUrl**: [`localizeUrl`](-internal-.md#localizeurl)
 
-Defined in: [runtime/type.ts:30](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:32](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### overwriteGetLocale
 
 > **overwriteGetLocale**: [`overwriteGetLocale`](-internal-.md#overwritegetlocale)
 
-Defined in: [runtime/type.ts:21](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:23](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### overwriteGetUrlOrigin
 
 > **overwriteGetUrlOrigin**: [`overwriteGetUrlOrigin`](-internal-.md#overwritegeturlorigin)
 
-Defined in: [runtime/type.ts:23](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:25](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### overwriteServerAsyncLocalStorage
 
 > **overwriteServerAsyncLocalStorage**: [`overwriteServerAsyncLocalStorage`](-internal-.md#overwriteserverasynclocalstorage)
 
-Defined in: [runtime/type.ts:24](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:26](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### overwriteSetLocale
 
 > **overwriteSetLocale**: [`overwriteSetLocale`](-internal-.md#overwritesetlocale)
 
-Defined in: [runtime/type.ts:22](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:24](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### routeStrategies
 
@@ -214,19 +220,19 @@ Defined in: [runtime/type.ts:8](https://github.com/opral/paraglide-js/tree/main/
 
 > **serverAsyncLocalStorage**: [`serverAsyncLocalStorage`](-internal-.md#serverasynclocalstorage)
 
-Defined in: [runtime/type.ts:13](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:14](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### setLocale
 
 > **setLocale**: [`setLocale`](-internal-.md#setlocale-1)
 
-Defined in: [runtime/type.ts:19](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:21](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### shouldRedirect
 
 > **shouldRedirect**: [`shouldRedirect`](-internal-.md#shouldredirect-1)
 
-Defined in: [runtime/type.ts:32](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:34](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### strategy
 
@@ -238,13 +244,19 @@ Defined in: [runtime/type.ts:7](https://github.com/opral/paraglide-js/tree/main/
 
 > **toLocale**: [`toLocale`](-internal-.md#tolocale)
 
-Defined in: [runtime/type.ts:25](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:27](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### trackMessageCall
 
 > **trackMessageCall**: [`trackMessageCall`](-internal-.md#trackmessagecall)
 
-Defined in: [runtime/type.ts:40](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:42](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
+
+#### trailingSlash
+
+> **trailingSlash**: [`trailingSlash`](-internal-.md#trailingslash)
+
+Defined in: [runtime/type.ts:12](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/type.ts)
 
 #### urlPatterns
 

--- a/docs/i18n-routing.md
+++ b/docs/i18n-routing.md
@@ -616,6 +616,18 @@ This is especially important for path-based localization where one locale has a 
 
 ### Trailing slashes
 
-URLPattern treats `/about` and `/about/` as different paths. To handle both consistently, your framework or server should normalize trailing slashes before the middleware runs. Most frameworks (Next.js, SvelteKit, Astro) handle this automatically.
+URLPattern treats `/about` and `/about/` as different paths. You can make Paraglide canonicalize localized URLs before matching and after generation with the `trailingSlash` compiler option:
 
-If you're seeing redirect loops involving trailing slashes, check your framework's trailing slash configuration.
+```ts
+paraglideVitePlugin({
+	project: "./project.inlang",
+	outdir: "./src/paraglide",
+	trailingSlash: "never", // or "always"
+});
+```
+
+`"never"` removes trailing slashes and `"always"` adds them. The root path `/` always remains `/`, while query parameters and hashes are preserved. Existing custom `urlPatterns` can keep their trailing slash style; Paraglide treats the other terminal-slash form as an alias when this option is set. Unmatched custom patterns remain unchanged.
+
+Omitting `trailingSlash` preserves the existing exact URLPattern behavior. This is useful when your framework already owns trailing slash normalization.
+
+If both Paraglide and your framework normalize trailing slashes, configure them with the same policy to avoid redirect loops.

--- a/src/compiler/compiler-options.ts
+++ b/src/compiler/compiler-options.ts
@@ -301,6 +301,14 @@ export type CompilerOptions = {
 	 */
 	urlPatterns?: Runtime["urlPatterns"];
 	/**
+	 * Controls trailing slash canonicalization for localized URLs.
+	 *
+	 * Canonicalization happens before URL pattern matching and after URL
+	 * localization. If omitted, Paraglide keeps its existing trailing slash
+	 * behavior.
+	 */
+	trailingSlash?: "always" | "never";
+	/**
 	 * Whether to include an eslint-disable comment at the top of each .js file.
 	 *
 	 * @default true

--- a/src/compiler/runtime/create-runtime.ts
+++ b/src/compiler/runtime/create-runtime.ts
@@ -15,6 +15,7 @@ export function createRuntimeFile(args: {
 		cookieMaxAge: NonNullable<CompilerOptions["cookieMaxAge"]>;
 		cookieDomain: CompilerOptions["cookieDomain"];
 		urlPatterns?: CompilerOptions["urlPatterns"];
+		trailingSlash?: CompilerOptions["trailingSlash"];
 		experimentalMiddlewareLocaleSplitting: CompilerOptions["experimentalMiddlewareLocaleSplitting"];
 		isServer: CompilerOptions["isServer"];
 		experimentalStaticLocale?: CompilerOptions["experimentalStaticLocale"];
@@ -115,6 +116,14 @@ ${injectCode("./variables.js")
 		`export const urlPatterns = ${JSON.stringify(urlPatterns, null, 2)};`
 	)
 	.replace(
+		`export const trailingSlash = undefined;`,
+		`export const trailingSlash = ${
+			args.compilerOptions.trailingSlash === undefined
+				? "undefined"
+				: JSON.stringify(args.compilerOptions.trailingSlash)
+		};`
+	)
+	.replace(
 		`export const disableAsyncLocalStorage = false;`,
 		`export const disableAsyncLocalStorage = ${args.compilerOptions.disableAsyncLocalStorage};`
 	)
@@ -164,6 +173,14 @@ ${injectCode("./set-locale.js")}
 ${injectCode("./get-url-origin.js")}
 
 ${injectCode("./check-locale.js")}
+
+${injectCode("./normalize-trailing-slash.js", {
+	privateExports: ["normalizeTrailingSlash"],
+})}
+
+${injectCode("./exec-url-pattern.js", {
+	privateExports: ["execUrlPattern"],
+})}
 
 ${injectCode("./extract-locale-from-request.js")}
 

--- a/src/compiler/runtime/exec-url-pattern.js
+++ b/src/compiler/runtime/exec-url-pattern.js
@@ -9,16 +9,23 @@ import { trailingSlash } from "./variables.js";
  * @returns {any}
  */
 export function execUrlPattern(pattern, url) {
-	const match = pattern.exec(url.href);
-	if (match || trailingSlash === undefined || url.pathname === "/") {
-		return match;
+	if (trailingSlash === undefined || url.pathname === "/") {
+		return pattern.exec(url.href);
 	}
 
 	const alias = new URL(url);
 	if (trailingSlash === "always") {
 		alias.pathname = alias.pathname.replace(/\/+$/, "") || "/";
+		// Prefer the slashless alias so the canonical slash does not become part
+		// of a terminal wildcard capture.
+		return pattern.exec(alias.href) ?? pattern.exec(url.href);
 	} else if (trailingSlash === "never") {
+		const match = pattern.exec(url.href);
+		if (match) {
+			return match;
+		}
 		alias.pathname = alias.pathname.replace(/\/+$/, "") + "/";
+		return pattern.exec(alias.href);
 	}
-	return pattern.exec(alias.href);
+	return pattern.exec(url.href);
 }

--- a/src/compiler/runtime/exec-url-pattern.js
+++ b/src/compiler/runtime/exec-url-pattern.js
@@ -1,0 +1,24 @@
+import { trailingSlash } from "./variables.js";
+
+/**
+ * Matches a canonical URL while allowing configured patterns to retain their
+ * existing trailing slash style.
+ *
+ * @param {URLPattern} pattern
+ * @param {URL} url
+ * @returns {any}
+ */
+export function execUrlPattern(pattern, url) {
+	const match = pattern.exec(url.href);
+	if (match || trailingSlash === undefined || url.pathname === "/") {
+		return match;
+	}
+
+	const alias = new URL(url);
+	if (trailingSlash === "always") {
+		alias.pathname = alias.pathname.replace(/\/+$/, "") || "/";
+	} else if (trailingSlash === "never") {
+		alias.pathname = alias.pathname.replace(/\/+$/, "") + "/";
+	}
+	return pattern.exec(alias.href);
+}

--- a/src/compiler/runtime/extract-locale-from-url.js
+++ b/src/compiler/runtime/extract-locale-from-url.js
@@ -4,6 +4,8 @@ import {
 	TREE_SHAKE_DEFAULT_URL_PATTERN_USED,
 	urlPatterns,
 } from "./variables.js";
+import { normalizeTrailingSlash } from "./normalize-trailing-slash.js";
+import { execUrlPattern } from "./exec-url-pattern.js";
 
 /**
  * If extractLocaleFromUrl is called many times on the same page and the URL
@@ -36,15 +38,22 @@ export function extractLocaleFromUrl(url) {
 	/** @type {Locale | undefined} */
 	let result;
 	if (TREE_SHAKE_DEFAULT_URL_PATTERN_USED) {
-		result = defaultUrlPatternExtractLocale(url);
+		const urlObj =
+			typeof url === "string"
+				? new URL(url, "http://example.com")
+				: new URL(url);
+		result = defaultUrlPatternExtractLocale(normalizeTrailingSlash(urlObj));
 	} else {
-		const urlObj = typeof url === "string" ? new URL(url) : url;
+		const urlObj = normalizeTrailingSlash(
+			typeof url === "string" ? new URL(url) : new URL(url)
+		);
 
 		// Iterate over URL patterns
 		for (const element of urlPatterns) {
 			for (const [locale, localizedPattern] of element.localized) {
-				const match = new URLPattern(localizedPattern, urlObj.href).exec(
-					urlObj.href
+				const match = execUrlPattern(
+					new URLPattern(localizedPattern, urlObj.href),
+					urlObj
 				);
 
 				if (match) {

--- a/src/compiler/runtime/generate-static-localized-urls.js
+++ b/src/compiler/runtime/generate-static-localized-urls.js
@@ -1,8 +1,11 @@
 import { localizeUrl } from "./localize-url.js";
+import { normalizeTrailingSlash } from "./normalize-trailing-slash.js";
+import { execUrlPattern } from "./exec-url-pattern.js";
 import {
 	locales,
 	baseLocale,
 	TREE_SHAKE_DEFAULT_URL_PATTERN_USED,
+	trailingSlash,
 	urlPatterns,
 } from "./variables.js";
 
@@ -56,10 +59,14 @@ export function generateStaticLocalizedUrls(urls) {
 	// For default URL pattern, we can optimize the generation
 	if (TREE_SHAKE_DEFAULT_URL_PATTERN_USED) {
 		for (const urlInput of urls) {
-			const url =
+			const originalUrl =
 				urlInput instanceof URL
 					? urlInput
 					: new URL(urlInput, "http://localhost");
+			const url =
+				trailingSlash === undefined
+					? originalUrl
+					: normalizeTrailingSlash(new URL(originalUrl));
 
 			// Base locale doesn't get a prefix
 			localizedUrls.add(url);
@@ -69,7 +76,7 @@ export function generateStaticLocalizedUrls(urls) {
 				if (locale !== baseLocale) {
 					const localizedPath = `/${locale}${url.pathname}${url.search}${url.hash}`;
 					const localizedUrl = new URL(localizedPath, url.origin);
-					localizedUrls.add(localizedUrl);
+					localizedUrls.add(normalizeTrailingSlash(localizedUrl));
 				}
 			}
 		}
@@ -78,18 +85,20 @@ export function generateStaticLocalizedUrls(urls) {
 
 	// For custom URL patterns, we need to use localizeUrl for each URL and locale
 	for (const urlInput of urls) {
-		const url =
+		const originalUrl =
 			urlInput instanceof URL
 				? urlInput
 				: new URL(urlInput, "http://localhost");
+		const url = normalizeTrailingSlash(new URL(originalUrl));
 
 		// Try each URL pattern to find one that matches
 		let patternFound = false;
 		for (const pattern of urlPatterns) {
 			try {
 				// Try to match the unlocalized pattern
-				const unlocalizedMatch = new URLPattern(pattern.pattern, url.href).exec(
-					url.href
+				const unlocalizedMatch = execUrlPattern(
+					new URLPattern(pattern.pattern, url.href),
+					url
 				);
 
 				if (!unlocalizedMatch) continue;
@@ -124,7 +133,7 @@ export function generateStaticLocalizedUrls(urls) {
 
 		// If no pattern matched, use the URL as is
 		if (!patternFound) {
-			localizedUrls.add(url);
+			localizedUrls.add(originalUrl);
 		}
 	}
 

--- a/src/compiler/runtime/generate-static-localized-urls.test.ts
+++ b/src/compiler/runtime/generate-static-localized-urls.test.ts
@@ -202,3 +202,53 @@ test("generates localized URLs from paths", async () => {
 	// All URLs should be URL objects
 	expect(urls.every((url) => url instanceof URL)).toBe(true);
 });
+
+test("applies trailing slash canonicalization to default pattern output", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		trailingSlash: "never",
+	});
+
+	const urls = runtime.generateStaticLocalizedUrls(["/", "/about/"]);
+	expect(urls.map((url) => url.pathname).sort()).toEqual([
+		"/",
+		"/about",
+		"/de",
+		"/de/about",
+	]);
+});
+
+test("canonicalizes custom pattern input but preserves unmatched URLs", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		trailingSlash: "never",
+		urlPatterns: [
+			{
+				pattern: "/about",
+				localized: [
+					["en", "/about"],
+					["de", "/de/ueber"],
+				],
+			},
+		],
+	});
+
+	const urls = runtime.generateStaticLocalizedUrls(["/about/", "/asset/"]);
+	expect(urls.map((url) => url.pathname).sort()).toEqual([
+		"/about",
+		"/asset/",
+		"/de/ueber",
+	]);
+});

--- a/src/compiler/runtime/localize-href.test.ts
+++ b/src/compiler/runtime/localize-href.test.ts
@@ -194,6 +194,28 @@ test("default url patterns to improve out of the box experience", async () => {
 	);
 });
 
+test("normalizes localized root hrefs and anchors", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		isServer: "false",
+		strategy: ["url"],
+		trailingSlash: "never",
+	});
+
+	globalThis.window = { location: new URL("http://example.com") } as any;
+
+	expect(runtime.localizeHref("/", { locale: "de" })).toBe("/de");
+	expect(runtime.localizeHref("/#section", { locale: "de" })).toBe(
+		"/de#section"
+	);
+	expect(runtime.deLocalizeHref("/de/")).toBe("/");
+});
+
 test("normalizes mixed-case explicit locales in localizeHref", async () => {
 	const runtime = await createParaglide({
 		blob: await newProject({

--- a/src/compiler/runtime/localize-url.js
+++ b/src/compiler/runtime/localize-url.js
@@ -5,8 +5,11 @@ import { assertIsLocale, toLocale } from "./check-locale.js";
 import {
 	baseLocale,
 	TREE_SHAKE_DEFAULT_URL_PATTERN_USED,
+	trailingSlash,
 	urlPatterns,
 } from "./variables.js";
+import { normalizeTrailingSlash } from "./normalize-trailing-slash.js";
+import { execUrlPattern } from "./exec-url-pattern.js";
 
 /**
  * Lower-level URL localization function, primarily used in server contexts.
@@ -61,13 +64,20 @@ export function localizeUrl(url, options) {
 		return localizeUrlDefaultPattern(url, targetLocale);
 	}
 
-	const urlObj = typeof url === "string" ? new URL(url) : url;
+	const originalUrl = typeof url === "string" ? new URL(url) : url;
+	const urlObj =
+		trailingSlash === undefined
+			? originalUrl
+			: normalizeTrailingSlash(new URL(originalUrl));
 
 	// Iterate over URL patterns
 	for (const element of urlPatterns) {
 		// match localized patterns
 		for (const [, localizedPattern] of element.localized) {
-			const match = getUrlPattern(localizedPattern, urlObj).exec(urlObj.href);
+			const match = execUrlPattern(
+				getUrlPattern(localizedPattern, urlObj),
+				urlObj
+			);
 
 			if (!match) {
 				continue;
@@ -86,10 +96,11 @@ export function localizeUrl(url, options) {
 				aggregateGroups(match),
 				urlObj.origin
 			);
-			return fillMissingUrlParts(localizedUrl, match);
+			return normalizeTrailingSlash(fillMissingUrlParts(localizedUrl, match));
 		}
-		const unlocalizedMatch = getUrlPattern(element.pattern, urlObj).exec(
-			urlObj.href
+		const unlocalizedMatch = execUrlPattern(
+			getUrlPattern(element.pattern, urlObj),
+			urlObj
 		);
 		if (unlocalizedMatch) {
 			const targetPattern = element.localized.find(
@@ -101,12 +112,14 @@ export function localizeUrl(url, options) {
 					aggregateGroups(unlocalizedMatch),
 					urlObj.origin
 				);
-				return fillMissingUrlParts(localizedUrl, unlocalizedMatch);
+				return normalizeTrailingSlash(
+					fillMissingUrlParts(localizedUrl, unlocalizedMatch)
+				);
 			}
 		}
 	}
 	// If no match found, return the original URL
-	return urlObj;
+	return originalUrl;
 }
 
 /**
@@ -117,14 +130,15 @@ export function localizeUrl(url, options) {
  * @returns {URL}
  */
 function localizeUrlDefaultPattern(url, locale) {
-	const urlObj =
-		typeof url === "string" ? new URL(url, getUrlOrigin()) : new URL(url);
+	const urlObj = normalizeTrailingSlash(
+		typeof url === "string" ? new URL(url, getUrlOrigin()) : new URL(url)
+	);
 
 	const currentLocale = extractLocaleFromUrl(urlObj);
 
 	// If current locale matches target locale, no change needed
 	if (currentLocale === locale) {
-		return urlObj;
+		return normalizeTrailingSlash(urlObj);
 	}
 
 	const pathSegments = urlObj.pathname.split("/").filter(Boolean);
@@ -142,7 +156,7 @@ function localizeUrlDefaultPattern(url, locale) {
 		urlObj.pathname = "/" + locale + "/" + pathSegments.join("/");
 	}
 
-	return urlObj;
+	return normalizeTrailingSlash(urlObj);
 }
 
 /**
@@ -189,25 +203,33 @@ export function deLocalizeUrl(url) {
 		return deLocalizeUrlDefaultPattern(url);
 	}
 
-	const urlObj = typeof url === "string" ? new URL(url) : url;
+	const originalUrl = typeof url === "string" ? new URL(url) : url;
+	const urlObj =
+		trailingSlash === undefined
+			? originalUrl
+			: normalizeTrailingSlash(new URL(originalUrl));
 
 	// Iterate over URL patterns
 	for (const element of urlPatterns) {
 		// Iterate over localized versions
 		for (const [, localizedPattern] of element.localized) {
-			const match = getUrlPattern(localizedPattern, urlObj).exec(urlObj.href);
+			const match = execUrlPattern(
+				getUrlPattern(localizedPattern, urlObj),
+				urlObj
+			);
 
 			if (match) {
 				// Convert localized URL back to the base pattern
 				const groups = aggregateGroups(match);
 
 				const baseUrl = fillPattern(element.pattern, groups, urlObj.origin);
-				return fillMissingUrlParts(baseUrl, match);
+				return normalizeTrailingSlash(fillMissingUrlParts(baseUrl, match));
 			}
 		}
 		// match unlocalized pattern
-		const unlocalizedMatch = getUrlPattern(element.pattern, urlObj).exec(
-			urlObj.href
+		const unlocalizedMatch = execUrlPattern(
+			getUrlPattern(element.pattern, urlObj),
+			urlObj
 		);
 		if (unlocalizedMatch) {
 			const baseUrl = fillPattern(
@@ -215,11 +237,13 @@ export function deLocalizeUrl(url) {
 				aggregateGroups(unlocalizedMatch),
 				urlObj.origin
 			);
-			return fillMissingUrlParts(baseUrl, unlocalizedMatch);
+			return normalizeTrailingSlash(
+				fillMissingUrlParts(baseUrl, unlocalizedMatch)
+			);
 		}
 	}
 	// no match found return the original url
-	return urlObj;
+	return originalUrl;
 }
 
 /**
@@ -228,8 +252,9 @@ export function deLocalizeUrl(url) {
  * @returns {URL}
  */
 function deLocalizeUrlDefaultPattern(url) {
-	const urlObj =
-		typeof url === "string" ? new URL(url, getUrlOrigin()) : new URL(url);
+	const urlObj = normalizeTrailingSlash(
+		typeof url === "string" ? new URL(url, getUrlOrigin()) : new URL(url)
+	);
 	const pathSegments = urlObj.pathname.split("/").filter(Boolean);
 
 	// If first segment is a locale, remove it
@@ -237,7 +262,7 @@ function deLocalizeUrlDefaultPattern(url) {
 		urlObj.pathname = "/" + pathSegments.slice(1).join("/");
 	}
 
-	return urlObj;
+	return normalizeTrailingSlash(urlObj);
 }
 
 /**

--- a/src/compiler/runtime/localize-url.test.ts
+++ b/src/compiler/runtime/localize-url.test.ts
@@ -78,6 +78,141 @@ test("pathname based localization", async () => {
 	);
 });
 
+// https://github.com/opral/paraglide-js/issues/473
+test("normalizes trailing slashes before matching translated pathnames", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url", "baseLocale"],
+		trailingSlash: "never",
+		urlPatterns: [
+			{
+				pattern: "/",
+				localized: [
+					["de", "/de"],
+					["en", "/"],
+				],
+			},
+			{
+				pattern: "/about",
+				localized: [
+					["de", "/de/ueber"],
+					["en", "/about"],
+				],
+			},
+		],
+	});
+
+	expect(runtime.trailingSlash).toBe("never");
+	expect("normalizeTrailingSlash" in runtime).toBe(false);
+	expect("execUrlPattern" in runtime).toBe(false);
+	expect(runtime.extractLocaleFromUrl("https://example.com/de/")).toBe("de");
+	expect(runtime.extractLocaleFromUrl("https://example.com/de/ueber/")).toBe(
+		"de"
+	);
+	expect(runtime.deLocalizeUrl("https://example.com/de/").href).toBe(
+		"https://example.com/"
+	);
+	expect(runtime.deLocalizeUrl("https://example.com/de/ueber/").href).toBe(
+		"https://example.com/about"
+	);
+	expect(
+		runtime.localizeUrl("https://example.com/about/", { locale: "de" }).href
+	).toBe("https://example.com/de/ueber");
+	expect(
+		runtime.localizeUrl("https://example.com/about/?ref=docs#section", {
+			locale: "de",
+		}).href
+	).toBe("https://example.com/de/ueber?ref=docs#section");
+});
+
+test("adds trailing slashes when configured", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		trailingSlash: "always",
+		urlPatterns: [
+			{
+				// Existing patterns do not need to be rewritten for the policy.
+				pattern: "/about",
+				localized: [
+					["de", "/de/ueber"],
+					["en", "/about"],
+				],
+			},
+		],
+	});
+
+	expect(
+		runtime.localizeUrl("https://example.com/about", { locale: "de" }).href
+	).toBe("https://example.com/de/ueber/");
+	expect(runtime.deLocalizeUrl("https://example.com/de/ueber").href).toBe(
+		"https://example.com/about/"
+	);
+});
+
+test("keeps unmatched custom URLs unchanged", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		trailingSlash: "never",
+		urlPatterns: [
+			{
+				pattern: "/about",
+				localized: [
+					["en", "/about"],
+					["de", "/de/ueber"],
+				],
+			},
+		],
+	});
+
+	const input = new URL("https://example.com/assets/");
+	expect(runtime.localizeUrl(input, { locale: "de" })).toBe(input);
+	expect(runtime.deLocalizeUrl(input)).toBe(input);
+	expect(input.href).toBe("https://example.com/assets/");
+});
+
+test("omitting trailingSlash preserves exact custom pattern matching", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		urlPatterns: [
+			{
+				pattern: "/about",
+				localized: [
+					["en", "/about"],
+					["de", "/de/ueber"],
+				],
+			},
+		],
+	});
+
+	const input = new URL("https://example.com/de/ueber/");
+	expect(runtime.trailingSlash).toBeUndefined();
+	expect(runtime.extractLocaleFromUrl(input)).toBeUndefined();
+	expect(runtime.deLocalizeUrl(input)).toBe(input);
+});
+
 test("cross domain urls", async () => {
 	const runtime = await createParaglide({
 		blob: await newProject({

--- a/src/compiler/runtime/localize-url.test.ts
+++ b/src/compiler/runtime/localize-url.test.ts
@@ -160,6 +160,35 @@ test("adds trailing slashes when configured", async () => {
 	);
 });
 
+test("does not include a canonical trailing slash in wildcard captures", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url"],
+		trailingSlash: "always",
+		urlPatterns: [
+			{
+				pattern: "/:path(.*)",
+				localized: [
+					["de", "/de/:path(.*)/details"],
+					["en", "/:path(.*)"],
+				],
+			},
+		],
+	});
+
+	expect(
+		runtime.localizeUrl("https://example.com/foo", { locale: "de" }).href
+	).toBe("https://example.com/de/foo/details/");
+	expect(runtime.deLocalizeUrl("https://example.com/de/foo/details").href).toBe(
+		"https://example.com/foo/"
+	);
+});
+
 test("keeps unmatched custom URLs unchanged", async () => {
 	const runtime = await createParaglide({
 		blob: await newProject({

--- a/src/compiler/runtime/normalize-trailing-slash.js
+++ b/src/compiler/runtime/normalize-trailing-slash.js
@@ -1,0 +1,24 @@
+import { trailingSlash } from "./variables.js";
+
+/**
+ * Applies the configured trailing slash policy to a URL.
+ *
+ * The root pathname always remains `/`. Query parameters and hashes are not
+ * modified.
+ *
+ * @param {URL} url
+ * @returns {URL}
+ */
+export function normalizeTrailingSlash(url) {
+	if (trailingSlash === undefined || url.pathname === "/") {
+		return url;
+	}
+
+	if (trailingSlash === "never") {
+		url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+	} else if (trailingSlash === "always") {
+		url.pathname = url.pathname.replace(/\/+$/, "") + "/";
+	}
+
+	return url;
+}

--- a/src/compiler/runtime/route-strategy.js
+++ b/src/compiler/runtime/route-strategy.js
@@ -1,4 +1,6 @@
 import { deLocalizeUrl } from "./localize-url.js";
+import { normalizeTrailingSlash } from "./normalize-trailing-slash.js";
+import { execUrlPattern } from "./exec-url-pattern.js";
 import { routeStrategies, strategy } from "./variables.js";
 
 /** @type {string | undefined} */
@@ -25,7 +27,9 @@ export function findMatchingRouteStrategy(url) {
 		return cachedRouteStrategy;
 	}
 
-	const publicUrl = new URL(urlString, "http://example.com");
+	const publicUrl = normalizeTrailingSlash(
+		new URL(urlString, "http://example.com")
+	);
 	const canonicalUrl = deLocalizeUrl(publicUrl);
 	const candidateUrls =
 		canonicalUrl.href === publicUrl.href
@@ -35,7 +39,7 @@ export function findMatchingRouteStrategy(url) {
 	for (const candidateUrl of candidateUrls) {
 		for (const routeStrategy of routeStrategies) {
 			const pattern = new URLPattern(routeStrategy.match, candidateUrl.href);
-			if (pattern.exec(candidateUrl.href)) {
+			if (execUrlPattern(pattern, candidateUrl)) {
 				match = routeStrategy;
 				break;
 			}

--- a/src/compiler/runtime/should-redirect.js
+++ b/src/compiler/runtime/should-redirect.js
@@ -7,6 +7,7 @@ import {
 	getStrategyForUrl,
 	isExcludedByRouteStrategy,
 } from "./route-strategy.js";
+import { trailingSlash } from "./variables.js";
 
 /**
  * @typedef {object} ShouldRedirectServerInput
@@ -180,6 +181,8 @@ function resolveUrl(input) {
  */
 function normalizeUrl(url) {
 	const urlObj = new URL(url);
-	urlObj.pathname = urlObj.pathname.replace(/\/$/, "");
+	if (trailingSlash === undefined) {
+		urlObj.pathname = urlObj.pathname.replace(/\/$/, "");
+	}
 	return urlObj.href;
 }

--- a/src/compiler/runtime/should-redirect.test.ts
+++ b/src/compiler/runtime/should-redirect.test.ts
@@ -36,6 +36,36 @@ test("shouldRedirect redirects to the strategy-preferred locale on the server", 
 	expect(decision.locale).toBe("fr");
 });
 
+test("shouldRedirect enforces the configured trailing slash policy", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url", "baseLocale"],
+		trailingSlash: "never",
+		urlPatterns: [
+			{
+				pattern: "/about",
+				localized: [
+					["de", "/de/ueber"],
+					["en", "/about"],
+				],
+			},
+		],
+	});
+
+	const decision = await runtime.shouldRedirect({
+		request: new Request("https://example.com/de/ueber/"),
+	});
+
+	expect(decision.locale).toBe("de");
+	expect(decision.shouldRedirect).toBe(true);
+	expect(decision.redirectUrl?.href).toBe("https://example.com/de/ueber");
+});
+
 test("shouldRedirect uses the provided public url when the transport request url differs", async () => {
 	const runtime = await createParaglide({
 		blob: await newProject({
@@ -241,7 +271,7 @@ test("shouldRedirect({ url }) resolves locale using target URL routeStrategies o
 		],
 		routeStrategies: [
 			{
-				match: "/dashboard/:path(.*)?",
+				match: "/dashboard",
 				strategy: ["cookie", "baseLocale"],
 			},
 		],
@@ -318,6 +348,7 @@ test("shouldRedirect respects routeStrategies that disable url strategy per rout
 		}),
 		strategy: ["url", "cookie", "baseLocale"],
 		cookieName: "PARAGLIDE_LOCALE",
+		trailingSlash: "never",
 		routeStrategies: [
 			{
 				match: "/dashboard/:path(.*)?",
@@ -326,7 +357,7 @@ test("shouldRedirect respects routeStrategies that disable url strategy per rout
 		],
 	});
 
-	const request = new Request("https://example.com/dashboard", {
+	const request = new Request("https://example.com/dashboard/", {
 		headers: {
 			cookie: "PARAGLIDE_LOCALE=fr",
 		},

--- a/src/compiler/runtime/type.ts
+++ b/src/compiler/runtime/type.ts
@@ -9,6 +9,7 @@ export type Runtime = {
 	cookieName: typeof import("./variables.js").cookieName;
 	cookieMaxAge: typeof import("./variables.js").cookieMaxAge;
 	urlPatterns: typeof import("./variables.js").urlPatterns;
+	trailingSlash: typeof import("./variables.js").trailingSlash;
 	disableAsyncLocalStorage: typeof import("./variables.js").disableAsyncLocalStorage;
 	serverAsyncLocalStorage: typeof import("./variables.js").serverAsyncLocalStorage;
 	getServerAsyncLocalStorage: typeof import("./variables.js").getServerAsyncLocalStorage;

--- a/src/compiler/runtime/variables.js
+++ b/src/compiler/runtime/variables.js
@@ -56,6 +56,13 @@ export const routeStrategies = [];
 export const urlPatterns = [];
 
 /**
+ * Controls trailing slash canonicalization for localized URLs.
+ *
+ * @type {"always" | "never" | undefined}
+ */
+export const trailingSlash = undefined;
+
+/**
  * @typedef {{
  * 		getStore(): {
  *   		locale?: Locale,

--- a/src/compiler/server/middleware.test.ts
+++ b/src/compiler/server/middleware.test.ts
@@ -887,6 +887,50 @@ test("prevents redirect loops by normalizing URLs with trailing slashes in diffe
 	);
 });
 
+// https://github.com/opral/paraglide-js/issues/473
+test("canonicalizes translated pathnames with the configured trailing slash policy", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url", "baseLocale"],
+		trailingSlash: "never",
+		urlPatterns: [
+			{
+				pattern: "/about",
+				localized: [
+					["en", "/about"],
+					["de", "/de/ueber"],
+				],
+			},
+		],
+	});
+
+	const response = await runtime.paraglideMiddleware(
+		new Request("https://example.com/de/ueber/", {
+			headers: { "Sec-Fetch-Dest": "document" },
+		}),
+		() => {
+			throw new Error("canonical document requests should redirect first");
+		}
+	);
+
+	expect(response.status).toBe(307);
+	expect(response.headers.get("Location")).toBe("https://example.com/de/ueber");
+
+	await runtime.paraglideMiddleware(
+		new Request("https://example.com/de/ueber/"),
+		({ locale, request }) => {
+			expect(locale).toBe("de");
+			expect(request.url).toBe("https://example.com/about");
+			return new Response();
+		}
+	);
+});
+
 // not implemented because users should disable redirects by
 // making another strategy preceed the url strategy
 //

--- a/src/compiler/server/runtime.d.ts
+++ b/src/compiler/server/runtime.d.ts
@@ -14,6 +14,7 @@ export declare const {
 	routeStrategies,
 	cookieName,
 	urlPatterns,
+	trailingSlash,
 	serverAsyncLocalStorage,
 	getServerAsyncLocalStorage,
 	experimentalMiddlewareLocaleSplitting,


### PR DESCRIPTION
## Summary

- add an opt-in `trailingSlash: "always" | "never"` compiler option
- canonicalize localized URLs before pattern matching and after URL generation
- preserve existing behavior when the option is omitted and leave unmatched custom routes unchanged
- keep existing `urlPatterns` valid by treating only the alternate terminal-slash form as an alias
- apply the policy consistently to helpers, route strategies, redirects, middleware, and static URL generation

## Why

Exact translated pathnames currently prevent framework trailing-slash settings from canonicalizing URLs such as `/de/` → `/de` and `/de/ueber/` → `/de/ueber`. This reproduces the TanStack Start report in #473 and also covers the root-anchor behavior from #480.

This deliberately does not change URLPattern ordering, captures, or unmatched-route fallthrough, and it does not address user-land helpers that explicitly generate a base-locale prefix.

## Verification

- `pnpm run build`
- `pnpm test` — 413 passed, 7 skipped
- targeted lint on changed source files
- two independent sub-agent reviews approved the final diff

Closes #473
Addresses #480
