### PR TITLE
chore: mark sdk v3 upgrade as minor

### DIFF
--- a/.changeset/upgrade-inlang-sdk-v3.md
+++ b/.changeset/upgrade-inlang-sdk-v3.md
@@ -1,5 +1,5 @@
 ---
-"@inlang/paraglide-js": patch
+"@inlang/paraglide-js": minor
 ---
 
 Upgrade to `@inlang/sdk` v3 and remove obsolete local account migration code.


### PR DESCRIPTION
## Summary

Mark the Inlang SDK v3 upgrade changeset as a minor release for `@inlang/paraglide-js` instead of a patch.

## Why

The dependency upgrade moves Paraglide to Inlang SDK v3 and should produce a minor Paraglide release.

## Validation

- `pnpm exec changeset status` reports `@inlang/paraglide-js` as the only minor bump
- no packages are reported for patch or major bumps
