### PR TITLE
chore: upgrade inlang sdk to 3.0.1

### DIFF
--- a/.changeset/bright-languages-upgrade.md
+++ b/.changeset/bright-languages-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Update the inlang SDK dependency to 3.0.1, which includes the Lix WASM fallback for musl-based Node.js environments.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	},
 	"dependencies": {
 		"@inlang/recommend-sherlock": "^0.2.1",
-		"@inlang/sdk": "^3.0.0",
+		"@inlang/sdk": "^3.0.1",
 		"commander": "11.1.0",
 		"consola": "3.4.0",
 		"json5": "2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       '@inlang/sdk':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1701,8 +1701,8 @@ packages:
     resolution: {integrity: sha512-cvz/C1rF5WBxzHbEoiBoI6Sz6q6M+TdxfWkEGBYTD77opY8i8WN01prUWXEM87GPF4SZcyIySez9U0Ccm12oFQ==}
     engines: {node: '>=18.0.0'}
 
-  '@inlang/sdk@3.0.0':
-    resolution: {integrity: sha512-jUo4NkxlreP22ZppCXygMp2gdgqkIcc0rt+dEruC9ylmESqRyWEF6muzIMsyU1CMKIhR6dxOtGG2v+H+MNu43w==}
+  '@inlang/sdk@3.0.1':
+    resolution: {integrity: sha512-QvyMYjCqF7CnrTp8ZaPiuwpmxsoQPIDgfqGeWfqi4FDxBREye4QdyaZS4DGwIlCZXybF/YMj0TtL2uBfbmajug==}
     engines: {node: '>=20.0.0'}
 
   '@inquirer/external-editor@1.0.3':
@@ -1774,28 +1774,28 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@lix-js/sdk-darwin-arm64@0.12.0':
-    resolution: {integrity: sha512-Pt6Q17kpvoTJCBaUdo5SfXuDFf1Fx2vODvnWlFILBmwV7xzUh9g2ALRF8nZr2jDWSeAi6g8PnjXDvryp2ug81g==}
+  '@lix-js/sdk-darwin-arm64@0.12.2':
+    resolution: {integrity: sha512-0mBRIfgZfaey1/d0mijv7fBIGPeaTIMCDOPr3s4RUlHy/j+llNmAyDS2iNlalFh9nQGys7JNzo2Hv3FQbdKmug==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lix-js/sdk-linux-arm64@0.12.0':
-    resolution: {integrity: sha512-tI+yZ6DOHIZhsblXMdMhFlq1k5m0Jc+/MF7im5MWzHk7KtYzdInW40uzg5NdjXkqlkFPsnugiNJzuCHCaW2XBg==}
+  '@lix-js/sdk-linux-arm64@0.12.2':
+    resolution: {integrity: sha512-817uJlC2KTIKDaqQvALTu03hEJpNxEA+9d33FNs8sOm9pAguOWiAK1zGA2SD0IgS9Q8NqQeABLb84OesW5/NCA==}
     cpu: [arm64]
     os: [linux]
 
-  '@lix-js/sdk-linux-x64@0.12.0':
-    resolution: {integrity: sha512-OTvkeZ3LNp3b1uHWBHGYPpeSQAv7NLj/kXbaUY1CMCyvZCFoWRvvz9Fmojv0mdWJV0j5qenJZF42XCiXVtcbrQ==}
+  '@lix-js/sdk-linux-x64@0.12.2':
+    resolution: {integrity: sha512-rA7lw1jBr6azBHR5Sh/RzOKSAlRcmVea7VeI4VQqpy0PZs+5tWoK9iVC41V4oCIKssRv2wrkbvyP3CqInhoknQ==}
     cpu: [x64]
     os: [linux]
 
-  '@lix-js/sdk-win32-x64@0.12.0':
-    resolution: {integrity: sha512-5THoK6ZEvYveHPmD23hEdxhElZw1OxunWof/ZCR6OlX2scfvCadEQ/snDAg1vXeelAh3VrZTh3fzPCO8rF/Rew==}
+  '@lix-js/sdk-win32-x64@0.12.2':
+    resolution: {integrity: sha512-y9IikCdrYx6cFnfqeUvYKPw6KBY016U2F2wYDILYZDZndccK2xw7lJChX163w9PewMwY3GsC/UqRBi5yqFAJ2w==}
     cpu: [x64]
     os: [win32]
 
-  '@lix-js/sdk@0.12.0':
-    resolution: {integrity: sha512-Vn4IYLmQyvqrVM+wcpzK6yDAZoK2Q4Hi9wRSsslfr1CcLQanRV1Tfheb5Kh2xy5NBLLbzFmFLsl7ElIKo8wVuA==}
+  '@lix-js/sdk@0.12.2':
+    resolution: {integrity: sha512-sKGOPdVKdChS5q60F4VQE4ZTcf0B7ZJM3KGCVQFN2suVNKhHcllbsCiwRYuM5WL7Yu1ql7YexltJ2FCsDqKePg==}
 
   '@lix-js/sdk@0.4.7':
     resolution: {integrity: sha512-pRbW+joG12L0ULfMiWYosIW0plmW4AsUdiPCp+Z8rAsElJ+wJ6in58zhD3UwUcd4BNcpldEGjg6PdA7e0RgsDQ==}
@@ -8835,9 +8835,9 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@inlang/sdk@3.0.0':
+  '@inlang/sdk@3.0.1':
     dependencies:
-      '@lix-js/sdk': 0.12.0
+      '@lix-js/sdk': 0.12.2
       '@sinclair/typebox': 0.31.28
       kysely: 0.28.16
       sqlite-wasm-kysely: 0.3.0(kysely@0.28.16)
@@ -8916,26 +8916,26 @@ snapshots:
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@lix-js/sdk-darwin-arm64@0.12.0':
+  '@lix-js/sdk-darwin-arm64@0.12.2':
     optional: true
 
-  '@lix-js/sdk-linux-arm64@0.12.0':
+  '@lix-js/sdk-linux-arm64@0.12.2':
     optional: true
 
-  '@lix-js/sdk-linux-x64@0.12.0':
+  '@lix-js/sdk-linux-x64@0.12.2':
     optional: true
 
-  '@lix-js/sdk-win32-x64@0.12.0':
+  '@lix-js/sdk-win32-x64@0.12.2':
     optional: true
 
-  '@lix-js/sdk@0.12.0':
+  '@lix-js/sdk@0.12.2':
     dependencies:
       fflate: 0.8.3
     optionalDependencies:
-      '@lix-js/sdk-darwin-arm64': 0.12.0
-      '@lix-js/sdk-linux-arm64': 0.12.0
-      '@lix-js/sdk-linux-x64': 0.12.0
-      '@lix-js/sdk-win32-x64': 0.12.0
+      '@lix-js/sdk-darwin-arm64': 0.12.2
+      '@lix-js/sdk-linux-arm64': 0.12.2
+      '@lix-js/sdk-linux-x64': 0.12.2
+      '@lix-js/sdk-win32-x64': 0.12.2
 
   '@lix-js/sdk@0.4.7(babel-plugin-macros@3.1.0)':
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade `@inlang/sdk` from `^3.0.0` to `^3.0.1`
- update the lockfile to `@inlang/sdk@3.0.1` and its Lix 0.12.2 dependency
- add a patch changeset for `@inlang/paraglide-js`

This picks up the inlang release containing the Lix 0.12.2 musl/Node.js WASM fallback.

## Validation

- `pnpm build`
- `pnpm test` — 45 files, 418 passed, 5 skipped
- `pnpm --filter @inlang/paraglide-js-example-vite build`
