### PR TITLE
fix(compiler): resolve chained local variable references

### DIFF
--- a/.changeset/fix-chained-local-variables.md
+++ b/.changeset/fix-chained-local-variables.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Resolve references to earlier local variables correctly in message declarations and formatter options.

--- a/src/compiler/compile-annotation.ts
+++ b/src/compiler/compile-annotation.ts
@@ -1,9 +1,10 @@
 import type {
+	Declaration,
 	FunctionReference,
 	Literal,
 	VariableReference,
 } from "@inlang/sdk";
-import { compileInputAccess } from "./variable-access.js";
+import { compileVariableAccess } from "./variable-access.js";
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
 
 /**
@@ -37,7 +38,8 @@ export function registryFunctionNamesForDisplay(): string {
 export function compileAnnotation(
 	str: string,
 	locale: string,
-	annotation?: FunctionReference
+	annotation?: FunctionReference,
+	declarations?: Declaration[]
 ): string {
 	if (!annotation) {
 		return str;
@@ -45,12 +47,13 @@ export function compileAnnotation(
 	if (annotation.name === "relativetime") {
 		validateRelativeTimeOptions(annotation);
 	}
-	return `registry.${annotation.name}("${locale}", ${str}, ${compileOptions(annotation.name, annotation.options)})`;
+	return `registry.${annotation.name}("${locale}", ${str}, ${compileOptions(annotation.name, annotation.options, declarations)})`;
 }
 
 function compileOptions(
 	annotationName: string,
-	options: FunctionReference["options"]
+	options: FunctionReference["options"],
+	declarations?: Declaration[]
 ): string {
 	if (options.length === 0) {
 		return "{}";
@@ -60,7 +63,8 @@ function compileOptions(
 			`${option.name}: ${compileOptionLiteralOrVarRef(
 				annotationName,
 				option.name,
-				option.value
+				option.value,
+				declarations
 			)}`
 	);
 	const code = "{ " + entries.join(", ") + " }";
@@ -97,13 +101,14 @@ const jsNonNegativeIntegerPattern = /^(?:0|[1-9]\d*)$/;
 function compileOptionLiteralOrVarRef(
 	annotationName: string,
 	optionName: string,
-	value: Literal | VariableReference
+	value: Literal | VariableReference,
+	declarations?: Declaration[]
 ): string {
 	if (value.type === "variable-reference") {
 		if (annotationName === "relativetime" && optionName === "unit") {
-			return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.name)})`;
+			return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileVariableAccess(value.name, declarations)})`;
 		}
-		return compileInputAccess(value.name);
+		return compileVariableAccess(value.name, declarations);
 	}
 
 	if (
@@ -111,7 +116,7 @@ function compileOptionLiteralOrVarRef(
 		optionName === "unit" &&
 		isDollarVariableReference(value.value)
 	) {
-		return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.value.slice(1))})`;
+		return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileVariableAccess(value.value.slice(1), declarations)})`;
 	}
 
 	if (shouldEmitNumberLiteral(annotationName, optionName, value.value)) {

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -28,6 +28,29 @@ test("compiles a variable reference local variable", () => {
 	expect(code).toEqual("const myVar = i?.name;");
 });
 
+test("compiles a variable reference to an earlier local variable", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declarations: [
+			{
+				type: "local-variable",
+				name: "earlierLocal",
+				value: { type: "expression", arg: { type: "literal", value: "42" } },
+			},
+		],
+		declaration: {
+			type: "local-variable",
+			name: "myVar",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "earlierLocal" },
+			},
+		},
+	});
+
+	expect(code).toEqual("const myVar = earlierLocal;");
+});
+
 test("compiles a variable reference local variable with a non-identifier name", () => {
 	const code = compileLocalVariable({
 		locale: "en",
@@ -88,6 +111,42 @@ test("compiles a local variable with an annotation and options", () => {
 	});
 	expect(code).toEqual(
 		'const myVar = registry.myFunction("en", "Hello", { option1: "value1", option2: i?.varRef });'
+	);
+});
+
+test("compiles formatter options referencing earlier local variables", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declarations: [
+			{ type: "input-variable", name: "amount" },
+			{
+				type: "local-variable",
+				name: "digits",
+				value: { type: "expression", arg: { type: "literal", value: "2" } },
+			},
+		],
+		declaration: {
+			type: "local-variable",
+			name: "formattedAmount",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "amount" },
+				annotation: {
+					type: "function-reference",
+					name: "number",
+					options: [
+						{
+							name: "minimumFractionDigits",
+							value: { type: "variable-reference", name: "digits" },
+						},
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedAmount = registry.number("en", i?.amount, { minimumFractionDigits: digits });'
 	);
 });
 
@@ -378,6 +437,39 @@ test("accepts dollar-prefixed relative time formatter unit options from message 
 
 	expect(code).toEqual(
 		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit) });'
+	);
+});
+
+test("compiles dollar-prefixed relative time units referencing local variables", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declarations: [
+			{ type: "input-variable", name: "duration" },
+			{
+				type: "local-variable",
+				name: "localUnit",
+				value: { type: "expression", arg: { type: "literal", value: "day" } },
+			},
+		],
+		declaration: {
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{ name: "unit", value: { type: "literal", value: "$localUnit" } },
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (localUnit) });'
 	);
 });
 

--- a/src/compiler/compile-local-variable.ts
+++ b/src/compiler/compile-local-variable.ts
@@ -1,5 +1,10 @@
-import type { Literal, LocalVariable, VariableReference } from "@inlang/sdk";
-import { compileInputAccess } from "./variable-access.js";
+import type {
+	Declaration,
+	Literal,
+	LocalVariable,
+	VariableReference,
+} from "@inlang/sdk";
+import { compileVariableAccess } from "./variable-access.js";
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
 import { compileAnnotation } from "./compile-annotation.js";
 
@@ -17,23 +22,28 @@ import { compileAnnotation } from "./compile-annotation.js";
 export function compileLocalVariable(args: {
 	locale: string;
 	declaration: LocalVariable;
+	declarations?: Declaration[];
 }): string {
 	const annotation = args.declaration.value.annotation;
 
 	const value = compileAnnotation(
-		compileLiteralOrVarRef(args.declaration.value.arg),
+		compileLiteralOrVarRef(args.declaration.value.arg, args.declarations),
 		args.locale,
-		annotation
+		annotation,
+		args.declarations
 	);
 
 	return `const ${args.declaration.name} = ${value};`;
 }
 
-function compileLiteralOrVarRef(value: Literal | VariableReference): string {
+function compileLiteralOrVarRef(
+	value: Literal | VariableReference,
+	declarations?: Declaration[]
+): string {
 	switch (value.type) {
 		case "literal":
 			return `"${escapeForDoubleQuoteString(value.value)}"`;
 		case "variable-reference":
-			return compileInputAccess(value.name);
+			return compileVariableAccess(value.name, declarations);
 	}
 }

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -30,11 +30,163 @@ test("compiles a message with a single variant", async () => {
 	expect(some_message()).toBe("Hello");
 });
 
+test.each(["single", "multiple"])(
+	"compiles chained local variables in %s-variant messages",
+	async (variantCount) => {
+		const declarations: Declaration[] = [
+			{ type: "input-variable", name: "count" },
+			{
+				type: "local-variable",
+				name: "zebra",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+				},
+			},
+			{
+				type: "local-variable",
+				name: "alpha",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "zebra" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [],
+					},
+				},
+			},
+		];
+		const message: Message = {
+			locale: "en",
+			bundleId: "chained_locals",
+			id: "chained-locals-id",
+			selectors:
+				variantCount === "multiple"
+					? [{ type: "variable-reference", name: "count" }]
+					: [],
+		};
+		const variants: Variant[] = [
+			{
+				id: "1",
+				messageId: "chained-locals-id",
+				matches:
+					variantCount === "multiple"
+						? [{ type: "literal-match", key: "count", value: "1" }]
+						: [],
+				pattern: [
+					{
+						type: "expression",
+						arg: { type: "variable-reference", name: "alpha" },
+					},
+				],
+			},
+		];
+
+		if (variantCount === "multiple") {
+			variants.push({
+				id: "2",
+				messageId: "chained-locals-id",
+				matches: [{ type: "catchall-match", key: "count" }],
+				pattern: [
+					{
+						type: "expression",
+						arg: { type: "variable-reference", name: "alpha" },
+					},
+				],
+			});
+		}
+
+		const compiled = compileMessage(declarations, message, variants);
+
+		expect(compiled.code).toContain(
+			'const alpha = registry.number("en", zebra, {});'
+		);
+
+		const { chained_locals } = await import(
+			"data:text/javascript;base64," +
+				btoa(
+					createRegistry() +
+						"\nexport const chained_locals = " +
+						compiled.code.replaceAll("registry.", "")
+				)
+		);
+
+		expect(chained_locals({ count: 42 })).toBe("42");
+	}
+);
+
+test("evaluates formatter options that reference earlier local variables", async () => {
+	const declarations: Declaration[] = [
+		{ type: "input-variable", name: "amount" },
+		{ type: "input-variable", name: "precision" },
+		{
+			type: "local-variable",
+			name: "digits",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "precision" },
+			},
+		},
+		{
+			type: "local-variable",
+			name: "formatted",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "amount" },
+				annotation: {
+					type: "function-reference",
+					name: "number",
+					options: [
+						{
+							name: "minimumFractionDigits",
+							value: { type: "variable-reference", name: "digits" },
+						},
+					],
+				},
+			},
+		},
+	];
+	const message: Message = {
+		locale: "en",
+		bundleId: "local_options",
+		id: "local-options-id",
+		selectors: [],
+	};
+	const variants: Variant[] = [
+		{
+			id: "1",
+			messageId: "local-options-id",
+			matches: [],
+			pattern: [
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "formatted" },
+				},
+			],
+		},
+	];
+
+	const compiled = compileMessage(declarations, message, variants);
+	const { local_options } = await import(
+		"data:text/javascript;base64," +
+			btoa(
+				createRegistry() +
+					"\nexport const local_options = " +
+					compiled.code.replaceAll("registry.", "")
+			)
+	);
+
+	expect(local_options({ amount: 42, precision: 2 })).toBe("42.00");
+});
+
 test("compiles pattern-level annotations to registry calls", async () => {
 	// https://github.com/opral/paraglide-js/issues/694
 	// i18next's `{{count, number}}` imports as an expression with a
 	// function-reference annotation directly on the pattern.
-	const declarations: Declaration[] = [{ type: "input-variable", name: "count" }];
+	const declarations: Declaration[] = [
+		{ type: "input-variable", name: "count" },
+	];
 	const message: Message = {
 		locale: "en",
 		bundleId: "views",
@@ -79,7 +231,9 @@ test("compiles pattern-level annotations to registry calls", async () => {
 });
 
 test("compiles pattern-level annotations in multi-variant messages", async () => {
-	const declarations: Declaration[] = [{ type: "input-variable", name: "count" }];
+	const declarations: Declaration[] = [
+		{ type: "input-variable", name: "count" },
+	];
 	const message: Message = {
 		locale: "en",
 		bundleId: "views_multi",

--- a/src/compiler/compile-message.ts
+++ b/src/compiler/compile-message.ts
@@ -67,7 +67,11 @@ function compileMessageWithOneVariant(
 	for (const declaration of declarations) {
 		if (declaration.type === "local-variable") {
 			compiledLocalVariables.push(
-				compileLocalVariable({ declaration, locale: message.locale })
+				compileLocalVariable({
+					declaration,
+					declarations,
+					locale: message.locale,
+				})
 			);
 		}
 	}
@@ -198,7 +202,11 @@ function compileMessageWithMultipleVariants(
 	for (const declaration of declarations) {
 		if (declaration.type === "local-variable") {
 			compiledLocalVariables.push(
-				compileLocalVariable({ declaration, locale: message.locale })
+				compileLocalVariable({
+					declaration,
+					declarations,
+					locale: message.locale,
+				})
 			);
 		}
 	}

--- a/src/compiler/compile-pattern.test.ts
+++ b/src/compiler/compile-pattern.test.ts
@@ -175,6 +175,42 @@ test("compiles pattern expression annotation options like local variable annotat
 	);
 });
 
+test("compiles pattern annotation options that reference local variables", () => {
+	const pattern: Pattern = [
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "price" },
+			annotation: {
+				type: "function-reference",
+				name: "number",
+				options: [
+					{
+						name: "minimumFractionDigits",
+						value: { type: "variable-reference", name: "digits" },
+					},
+				],
+			},
+		},
+	];
+
+	const { code } = compilePattern({
+		pattern,
+		declarations: [
+			{ type: "input-variable", name: "price" },
+			{
+				type: "local-variable",
+				name: "digits",
+				value: { type: "expression", arg: { type: "literal", value: "2" } },
+			},
+		],
+		locale: "en",
+	});
+
+	expect(code).toBe(
+		'`${registry.number("en", i?.price, { minimumFractionDigits: digits })}`'
+	);
+});
+
 test("parts mode compiles pattern expression annotations to registry calls", () => {
 	const pattern: Pattern = [
 		{

--- a/src/compiler/compile-pattern.ts
+++ b/src/compiler/compile-pattern.ts
@@ -172,7 +172,7 @@ function compileExpression(
 		);
 	}
 
-	return compileAnnotation(value, locale, annotation);
+	return compileAnnotation(value, locale, annotation, declarations);
 }
 
 function compileExpressionValue(
@@ -232,7 +232,9 @@ function compileMarkupAttributes(attributes: Attribute[]): string {
 	return `{ ${attributes
 		.map((attribute) => {
 			const value =
-				attribute.value === true ? "true" : stringLiteral(attribute.value.value);
+				attribute.value === true
+					? "true"
+					: stringLiteral(attribute.value.value);
 			return `${stringLiteral(attribute.name)}: ${value}`;
 		})
 		.join(", ")} }`;

--- a/src/compiler/variable-access.ts
+++ b/src/compiler/variable-access.ts
@@ -1,3 +1,4 @@
+import type { Declaration } from "@inlang/sdk";
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
 
 const identifierPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
@@ -15,4 +16,16 @@ export function compileInputAccess(name: string): string {
 		return `i?.${name}`;
 	}
 	return `i?.[${quotePropertyKey(name)}]`;
+}
+
+export function compileVariableAccess(
+	name: string,
+	declarations?: Declaration[]
+): string {
+	const declaration = declarations?.find(
+		(candidate) => candidate.name === name
+	);
+	return declaration?.type === "local-variable"
+		? name
+		: compileInputAccess(name);
 }


### PR DESCRIPTION
## Summary

- Resolve references to earlier local declarations through their generated local bindings instead of incorrectly reading them from message inputs.
- Apply the same declaration-aware resolution to formatter options, relative-time unit options, and pattern-level annotations.
- Cover both single- and multi-variant execution, chained local values, and formatter options referencing local variables.
- Add a patch changeset for `@inlang/paraglide-js`.

## Verification

- `pnpm run build`.
- `pnpm run test` (45 files; 427 passed, 5 skipped; includes TypeScript checking and coverage).
- `pnpm exec vitest run src/compiler/compile-local-variable.test.ts src/compiler/compile-pattern.test.ts src/compiler/compile-message.test.ts` (63 passed).
- Prettier check for every modified compiler source/test file.
- Independent subagent review approved the implementation and regressions.

Companion message-format fixes: https://github.com/opral/inlang/pull/4407
