### PR TITLE
fix(compiler): use a replacer function for compiledBundles to avoid $-pattern corruption

### DIFF
--- a/.changeset/silly-actors-jump.md
+++ b/.changeset/silly-actors-jump.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Fix `experimentalMiddlewareLocaleSplitting` corrupting the generated server file when a compiled message value contains a literal `$` (e.g. a price or currency symbol) that forms a `String.replace()` special replacement pattern such as `` $` ``.

--- a/src/compiler/server/create-server-file.test.ts
+++ b/src/compiler/server/create-server-file.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, expect, test } from "vitest";
+import type { CompiledBundleWithMessages } from "../compile-bundle.js";
 import { createServerFile } from "./create-server-file.js";
 
 const temporaryDirectories: string[] = [];
@@ -64,4 +65,63 @@ export const isExcludedByRouteStrategy = runtime.isExcludedByRouteStrategy;`
 
 	expect(response.status).toBe(200);
 	expect(await response.text()).toBe("ready");
+});
+
+test("a literal '$' in a compiled message does not corrupt the generated file (experimentalMiddlewareLocaleSplitting)", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "paraglide-server-dollar-"));
+	temporaryDirectories.push(directory);
+
+	// The compiled message source for locale "en" evaluates to the literal
+	// text "$", wrapped in a template literal by the compiler (i.e. it
+	// contains a backtick immediately followed by a `$` immediately followed
+	// by another backtick). Passed as a *string* to `code.replace()`, `` $` ``
+	// is a special replacement pattern ("insert everything before the
+	// match"), which splices the file's own header into the string being
+	// built and corrupts the generated server file.
+	const compiledBundles = [
+		{
+			bundle: { node: { id: "price_symbol" } },
+			messages: {
+				en: { code: "export const price_symbol = () => `$`;" },
+			},
+		},
+	] as unknown as CompiledBundleWithMessages[];
+
+	const serverCode = createServerFile({
+		compiledBundles,
+		compilerOptions: {
+			disableAsyncLocalStorage: false,
+			experimentalMiddlewareLocaleSplitting: true,
+		},
+	});
+
+	// The message value must survive JSON serialization untouched.
+	expect(serverCode).toContain('"price_symbol":{"en":"() => `$`"}');
+
+	// The generated file must still be syntactically valid and importable
+	// (the bug produces an unterminated string / invalid JS).
+	await writeFile(
+		join(directory, "runtime.js"),
+		`export const serverAsyncLocalStorage = undefined;
+export const disableAsyncLocalStorage = false;
+export const experimentalMiddlewareLocaleSplitting = true;
+export const baseLocale = "en";
+export function isExcludedByRouteStrategy() {
+  return true;
+}
+export function getStrategyForUrl() {
+  return [];
+}
+export async function shouldRedirect() {
+  return { locale: "en", shouldRedirect: false };
+}
+export function deLocalizeUrl(url) {
+  return url;
+}`
+	);
+	await writeFile(join(directory, "server.mjs"), serverCode);
+
+	await expect(
+		import(pathToFileURL(join(directory, "server.mjs")).href)
+	).resolves.toBeDefined();
 });

--- a/src/compiler/server/create-server-file.ts
+++ b/src/compiler/server/create-server-file.ts
@@ -68,9 +68,19 @@ ${injectCode("./middleware.js")}
 		code.slice(endOfMarkerLine);
 
 	if (args.compilerOptions.experimentalMiddlewareLocaleSplitting) {
+		// Use a replacer function, not a replacement string. `String.replace()`
+		// treats a string replacement as a pattern where `$&`, `` $` ``, `$'`,
+		// `$$`, and `$<name>` have special meaning. A translated message value
+		// that contains a literal `$` (a price, a currency symbol) can produce
+		// one of these sequences inside the JSON payload, which `String.replace`
+		// then expands - e.g. `` $` `` is replaced with "everything before the
+		// match", splicing the file's own header into the string being built and
+		// corrupting the generated server file. A function's return value is
+		// used literally, with no pattern expansion.
 		code = code.replace(
 			"const compiledBundles = {};",
-			`const compiledBundles = ${JSON.stringify(createCompiledMessagesObject(args.compiledBundles))};`
+			() =>
+				`const compiledBundles = ${JSON.stringify(createCompiledMessagesObject(args.compiledBundles))};`
 		);
 	}
 


### PR DESCRIPTION
**What breaks:** with `experimentalMiddlewareLocaleSplitting` enabled, `createServerFile()` splices the compiled messages JSON into `server.js` via `code.replace(marker, jsonString)`, passing the JSON as a *string* replacement. `String.replace()` treats `$&`, `` $` ``, `$'`, `$$`, `$<name>` in a string replacement as special patterns, not literal text. A compiled message whose value contains a literal `$` (a price, a currency symbol) can produce one of these sequences inside the JSON payload, corrupting the generated `server.js` into invalid JS (an unterminated string, with the error pointing nowhere near the real cause).

**Repro:** compile a bundle with `experimentalMiddlewareLocaleSplitting: true` where a message's compiled value contains a backtick immediately followed by `$`+backtick (e.g. a template-literal-compiled `` `$` ``) — the generated server file gets the file's own header spliced into the string literal being built.

**Fix:** pass a replacer *function* (`() => ...`) to `code.replace()` instead of a string — a function's return value is inserted literally, with no `$`-pattern expansion. One line, behavior-preserving for every input without this edge case.

Added a unit test with a fixture message containing this sequence, asserting the JSON payload survives untouched and the generated file is still importable.

Found while evaluating this experimental flag on a SvelteKit app. It's documented as experimental/SSR-only (#88) — this fix (and a companion one for the `compiledBundles` keying, opened separately) are prerequisites for anyone trying it.