### PR TITLE
fix(compiler): key compiledBundles by the safe module id

### DIFF
--- a/.changeset/tame-donkeys-jog.md
+++ b/.changeset/tame-donkeys-jog.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Fix `experimentalMiddlewareLocaleSplitting` keying `compiledBundles` by the raw bundle id instead of the safe module id, so every SSR message lookup missed and threw `globalThis.__paraglide.ssr.<id> is not a function` on hydration.

--- a/src/compiler/server/create-server-file.test.ts
+++ b/src/compiler/server/create-server-file.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, expect, test } from "vitest";
+import type { CompiledBundleWithMessages } from "../compile-bundle.js";
+import { toSafeModuleId } from "../safe-module-id.js";
 import { createServerFile } from "./create-server-file.js";
 
 const temporaryDirectories: string[] = [];
@@ -64,4 +66,35 @@ export const isExcludedByRouteStrategy = runtime.isExcludedByRouteStrategy;`
 
 	expect(response.status).toBe(200);
 	expect(await response.text()).toBe("ready");
+});
+
+test("keys compiledBundles by the safe module id, not the raw bundle id (experimentalMiddlewareLocaleSplitting)", () => {
+	// A bundle id that changes under toSafeModuleId (case-folded + a numeric
+	// suffix appended for the uppercase letters). trackMessageCall(), the
+	// client's SSR message guard, and middleware.js all look up
+	// compiledBundles by this safe id - only createCompiledMessagesObject
+	// (inside createServerFile) used the raw id instead.
+	const bundleId = "GREETING";
+	const safeModuleId = toSafeModuleId(bundleId);
+	expect(safeModuleId).not.toBe(bundleId);
+
+	const compiledBundles = [
+		{
+			bundle: { node: { id: bundleId } },
+			messages: {
+				en: { code: `export const ${safeModuleId} = () => "hello";` },
+			},
+		},
+	] as unknown as CompiledBundleWithMessages[];
+
+	const serverCode = createServerFile({
+		compiledBundles,
+		compilerOptions: {
+			disableAsyncLocalStorage: false,
+			experimentalMiddlewareLocaleSplitting: true,
+		},
+	});
+
+	expect(serverCode).toContain(`"${safeModuleId}":{"en":`);
+	expect(serverCode).not.toContain(`"${bundleId}":{"en":`);
 });

--- a/src/compiler/server/create-server-file.ts
+++ b/src/compiler/server/create-server-file.ts
@@ -85,13 +85,18 @@ function createCompiledMessagesObject(
 	for (const compiledBundle of compiledBundles) {
 		const bundleId = compiledBundle.bundle.node.id;
 		const safeModuleId = toSafeModuleId(bundleId);
-		if (result[bundleId] === undefined) {
-			result[bundleId] = {};
+		// Key by the safe module id, not the raw bundle id: trackMessageCall()
+		// records calls under safeModuleId, the client reads
+		// globalThis.__paraglide.ssr[safeModuleId], and middleware.js looks up
+		// compiledBundles[id] with that same safe id. Keying by the raw
+		// bundleId here made every split-mode lookup miss.
+		if (result[safeModuleId] === undefined) {
+			result[safeModuleId] = {};
 		}
 		for (const [locale, compiledMessage] of Object.entries(
 			compiledBundle.messages
 		)) {
-			result[bundleId][locale] = compiledMessage.code
+			result[safeModuleId][locale] = compiledMessage.code
 				.replace(`export const ${safeModuleId} = `, "")
 				.replace(/;$/, "");
 		}


### PR DESCRIPTION
**What breaks:** with `experimentalMiddlewareLocaleSplitting` enabled, `createCompiledMessagesObject()` (in `createServerFile()`) computes `safeModuleId` only to strip the `export const ... =` prefix off each compiled message, but keys the resulting object by the **raw** bundle id instead. `trackMessageCall()`, the client's SSR message guard, and `middleware.js` all look up `compiledBundles` by the safe module id. So every lookup misses, and every message on every split-mode page throws `globalThis.__paraglide.ssr.<id> is not a function` on hydration — unconditionally, for 100% of bundles.

**Repro:** compile any bundle whose id changes under `toSafeModuleId` (e.g. contains uppercase letters) with `experimentalMiddlewareLocaleSplitting: true` — `compiledBundles` in the generated server file is keyed by the raw id, not the id everything else looks it up by.

**Fix:** key the object by `safeModuleId`, the value the function was already computing and discarding. Confined entirely to the `experimentalMiddlewareLocaleSplitting` path, so it cannot regress non-split builds.

Added a unit test with a bundle id that changes under `toSafeModuleId`, asserting the emitted object is keyed by the safe id and not the raw one.

Found while evaluating this experimental flag on a SvelteKit app. It's documented as experimental/SSR-only (#88) — this fix (and a companion one for the `$`-pattern corruption in the same file, opened separately as #762) are prerequisites for anyone trying it.